### PR TITLE
Foundation: add real-media quality regression gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - agent/clipping-factory-buildout
+      - "agent/**"
+  pull_request:
+    branches:
+      - main
+      - agent/clipping-factory-buildout
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    name: fmt · clippy · test · eval fixtures
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Formatting
+        run: cargo fmt --all --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Rust tests
+        run: cargo test
+
+      - name: Eval runner syntax
+        run: bash -n evals/run.sh
+
+      - name: Eval report syntax
+        run: python3 -m py_compile evals/report.py
+
+      - name: Eval fixture tests
+        run: python3 -m unittest discover -s evals/tests -v

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.qa-output/
 /target/
 
-# Eval harness inputs/outputs (local media, never committed)
+# Eval harness inputs/outputs (local media, local manifest, generated reports)
+/evals/manifest.json
 /evals/sources/
 /evals/results/

--- a/docs/agent/GSTACK_ISSUE_3_PLAN.md
+++ b/docs/agent/GSTACK_ISSUE_3_PLAN.md
@@ -1,0 +1,187 @@
+# G Stack example: Issue #3 quality regression gate
+
+## Example user prompt
+
+> Implement issue #3, the real-media quality regression gate, on a new branch
+> from `agent/clipping-factory-buildout`. Use the full G Stack loop: shape the
+> product decision, review strategy and engineering, build it, review the diff,
+> test it, and open a draft PR. Do not merge it.
+
+## Office hours
+
+### 1. Demand reality
+
+The feature is not directly purchased, but it protects the paid product from
+shipping visibly worse selection, captions, framing, or rendering. The demand
+signal is the repository roadmap itself: every later quality-sensitive feature
+depends on this gate.
+
+### 2. Status quo
+
+The repository has 62 deterministic Rust tests, a manual eval README, a simple
+upload loop, and a CI file parked under `docs/`. It does not have active CI,
+versioned source metadata, reproducible run metadata, partial-failure
+preservation, deterministic aggregation, or baseline deltas.
+
+### 3. Desperate specificity
+
+A maintainer needs to answer one concrete question before merging a media
+pipeline change:
+
+> Did this branch introduce source failures or make human-reviewed output
+> measurably worse than the accepted baseline?
+
+The answer must be backed by a report that can be attached to a PR.
+
+### 4. Narrowest wedge
+
+Build a local, privacy-preserving quality ratchet:
+
+1. activate deterministic CI;
+2. run a versioned local manifest through the real HTTP product path;
+3. preserve per-source evidence even when a later source fails;
+4. aggregate operational and human-review metrics;
+5. compare against a baseline with explicit thresholds.
+
+Do not add cloud storage, an AI judge, production schema changes, or committed
+media.
+
+### 5. Observation plan
+
+The first useful observation is a deliberately degraded or failed run compared
+with a known-good synthetic baseline. The gate must identify:
+
+- a new source failure;
+- a would-post-rate drop;
+- a rubric-average drop;
+- the exact source error;
+- deterministic report output across repeated generation.
+
+### 6. Future fit
+
+The report schema should accept more metrics later without rewriting existing
+runs. The runner must remain usable for transcript correction, boundaries,
+framing, audio QC, presets, and batch processing work.
+
+## CEO review
+
+**Mode: selective expansion.**
+
+The premise is valid. The roadmap explicitly makes this the first
+implementation dependency. The dangerous expansion would be trying to
+automatically score creative quality. Human review remains authoritative.
+
+Scope decisions:
+
+- Keep: active CI, manifest, run metadata, partial results, report, baseline
+  comparison, thresholds, deterministic fixtures, documentation.
+- Add: privacy rule that absolute source paths never enter committed reports.
+- Add: a resumable run mode because long local media runs are interruption
+  prone.
+- Reject: hosted dashboard, database, LLM judge, committed media, exact
+  cross-machine performance gates.
+- Defer: generating synthetic MP4 fixtures through FFmpeg in CI. The report and
+  state parser can be validated without downloading models or exercising the
+  full production pipeline.
+
+## Design review
+
+Skipped. This change has no product UI scope. The Markdown report is a
+developer artifact, and its hierarchy is specified by operational summary,
+human review, baseline status, and per-source evidence.
+
+## Engineering review
+
+### Architecture
+
+- `evals/run.sh` owns orchestration through the real local HTTP API.
+- `evals/report.py` owns deterministic parsing, aggregation, comparison, and
+  rendering.
+- `metadata.json`, per-source `result.json`, and the copied `view.json` form the
+  durable evidence boundary.
+- `rubric.csv` remains the human input.
+- `.github/workflows/ci.yml` runs Rust checks plus deterministic eval fixtures.
+
+This separates side effects from pure report logic and avoids production code
+changes.
+
+### Error paths
+
+- Missing manifest or source file fails clearly.
+- A missing source records a failed `result.json` and does not discard prior
+  sources.
+- Upload failures and three consecutive polling failures become source-level
+  errors.
+- Per-source timeout is configurable.
+- Interrupted terminal sources can be skipped with `--resume`.
+- Invalid rubric scores are excluded and listed by row number.
+- Baseline data without current human ratings warns rather than inventing
+  scores.
+
+### Security and privacy
+
+- Media and result directories remain gitignored.
+- Reports store source IDs and file names, not absolute paths.
+- Transcript content is not copied into the aggregate report.
+- No network service is added beyond the existing localhost studio.
+- Untrusted strings are escaped in Markdown table cells.
+
+### Performance
+
+- The runner processes sequentially to match current pipeline behavior.
+- Reports stream small JSON/CSV files and are negligible compared with media
+  processing.
+- Timing is recorded but not enforced across different hardware.
+
+## Developer experience review
+
+Target time to first useful run:
+
+1. copy the example manifest;
+2. edit local paths;
+3. start the studio;
+4. run `bash evals/run.sh`.
+
+The command emits the result directory and report path. Errors name the missing
+dependency or failed source. No new package manager or project dependency is
+required. Python uses the standard library only.
+
+## Test plan
+
+Automated:
+
+- `bash -n evals/run.sh`
+- `python3 -m py_compile evals/report.py`
+- `python3 -m unittest discover -s evals/tests -v`
+- existing `cargo fmt`, `cargo clippy`, and `cargo test`
+
+Fixture coverage:
+
+- one complete source and one failed source;
+- accepted, rejected, and duplicate/overlap rejection counts;
+- human rubric averages and would-post rate;
+- false-accept tracking;
+- baseline failure on new source failure and score regression;
+- deterministic repeated JSON and Markdown output;
+- invalid score handling.
+
+Manual after merge candidate:
+
+- run a local six-slot manifest;
+- interrupt and resume one run;
+- compare a normal run against a deliberately degraded configuration;
+- confirm no media or absolute path appears in Git.
+
+## Completion definition
+
+- [x] Branch created from `agent/clipping-factory-buildout`
+- [x] Plan reviewed for strategy, engineering, and developer experience
+- [x] Active CI workflow added
+- [x] Versioned manifest example and committed thresholds added
+- [x] Resumable partial-failure runner implemented
+- [x] Deterministic report and baseline gate implemented
+- [x] Synthetic fixture tests implemented
+- [x] Eval documentation and PR policy updated
+- [ ] GitHub Actions green
+- [ ] Draft PR opened
+- [ ] Independent diff review completed

--- a/docs/ci-workflow.yml
+++ b/docs/ci-workflow.yml
@@ -1,25 +1,25 @@
-# GitHub Actions CI for Clipping Factory.
-#
-# GitHub's API refuses workflow-file writes without the 'workflow' OAuth
-# scope, so this file ships here instead of .github/workflows/. Activate
-# it with one command from the repo root:
-#
-#   mkdir -p .github/workflows && cp docs/ci-workflow.yml .github/workflows/ci.yml \
-#     && git add .github/workflows/ci.yml && git commit -m 'chore(ci): enable CI' && git push
-#
+# Reference copy of the active workflow at `.github/workflows/ci.yml`.
+# Keep both files identical below this comment when editing CI.
+
 name: CI
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - agent/clipping-factory-buildout
+      - "agent/**"
   pull_request:
+    branches:
+      - main
+      - agent/clipping-factory-buildout
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   check:
-    name: fmt · clippy · test
+    name: fmt · clippy · test · eval fixtures
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,9 +27,21 @@ jobs:
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+
       - name: Formatting
         run: cargo fmt --all --check
-      - name: Clippy (deny warnings)
+
+      - name: Clippy
         run: cargo clippy --all-targets -- -D warnings
-      - name: Tests
+
+      - name: Rust tests
         run: cargo test
+
+      - name: Eval runner syntax
+        run: bash -n evals/run.sh
+
+      - name: Eval report syntax
+        run: python3 -m py_compile evals/report.py
+
+      - name: Eval fixture tests
+        run: python3 -m unittest discover -s evals/tests -v

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,56 +1,181 @@
 # Eval harness — the quality ratchet
 
-Clipping Factory's quality lives in *output judgment*: did it pick moments
-worth posting? Are captions word-accurate? Did framing hold the speaker?
-None of that shows up in unit tests. This harness turns "make it better"
-into a measurement.
+Clipping Factory's quality lives in output judgment: did it find moments worth
+posting, preserve context, keep captions accurate, and frame the speaker
+reliably? Unit tests protect deterministic code. This harness adds the
+real-media evidence required before changing selection, validation, framing,
+captions, audio, or rendering.
 
-## Golden set
+Media, models, local paths, and generated clips remain outside Git.
 
-Put 5–10 real episodes in `evals/sources/` (gitignored — media never gets
-committed). Cover the failure modes that matter:
-
-| Slot | Source type | What it stresses |
-|---|---|---|
-| 1 | Two-person interview, clean audio | the happy path |
-| 2 | Solo monologue | ranking without conversational turns |
-| 3 | Panel (3+ voices) | framing fallback, crosstalk transcription |
-| 4 | Noisy / room-tone recording | transcription confidence, caption accuracy |
-| 5 | Accented or fast speech | word timestamps under pressure |
-| 6+ | Your actual content | the distribution you really ship |
-
-## Running
+## 1. Create your local manifest
 
 ```bash
-# Terminal 1: the studio
-cargo run --release
-
-# Terminal 2: run every source through the pipeline
-bash evals/run.sh            # uploads each MP4, polls to completion,
-                               # collects manifests into evals/results/<run>/
+cp evals/manifest.example.json evals/manifest.json
 ```
 
-Each run directory ends up with, per source: `view.json` (final project view:
-accepted clips, rejected candidates with named reasons, selector used) and a
-copy of `rubric.csv` to fill in.
+Edit `evals/manifest.json` so every `path` points to a local source. Relative
+paths are resolved from the manifest's directory. The committed example covers
+the minimum useful distribution:
 
-## Scoring
+| Category | What it stresses |
+|---|---|
+| Two-person interview, clean audio | Happy path |
+| Solo monologue | Ranking without conversational turns |
+| Panel, 3+ voices | Crosstalk and framing fallback |
+| Noisy / room-tone recording | Confidence and caption accuracy |
+| Fast or accented speech | Word timestamps and quote matching |
+| Actual target content | The distribution the product must serve |
 
-Watch every produced clip. Score 1–5 per row in `rubric.csv`:
+The manifest is versioned, but your filled `evals/manifest.json` and media
+should stay local. The runner snapshots the manifest into each result directory
+for local evidence. Generated results are gitignored; reports identify sources
+by manifest ID, not by local path.
 
-- **hook** — do the first 3 seconds earn a stop-scroll?
-- **standalone** — fully understandable with zero episode context?
-- **payoff** — does it land somewhere, or just trail off?
-- **caption_accuracy** — words correct and on-beat with speech?
-- **framing** — speaker held steady, no drift, no crop-through-face?
-- **would_post** — the only score that really matters (yes=5 / no=1)
+## 2. Run the full set
 
-Also record: clips produced, clips you'd actually post, and any rejected
-candidate that should have been accepted (validator too strict) or accepted
-clip that should have been rejected (validator too loose).
+Start the studio:
 
-## The rule
+```bash
+cargo run --release
+```
 
-Before merging any change to `src/select/`, `src/validate.rs`, `src/frame.rs`,
-or `src/captions.rs`: run the golden set, compare scores to the previous run,
-and put the delta in the PR description. No score, no merge.
+In another terminal:
+
+```bash
+bash evals/run.sh
+```
+
+Useful options:
+
+```bash
+# Compare against the accepted baseline and fail on configured regressions.
+bash evals/run.sh \
+  --baseline evals/results/20260730T120000Z \
+  --thresholds evals/thresholds.json \
+  --enforce
+
+# Resume an interrupted run without reprocessing completed sources; failed sources are retried.
+bash evals/run.sh \
+  --run-dir evals/results/20260730T130000Z \
+  --resume
+```
+
+The runner:
+
+1. verifies the studio and manifest;
+2. snapshots commit, branch, tool versions, platform, safe environment checks, and manifest hash;
+3. uploads each source only to the fixed loopback studio at `127.0.0.1:4571` and polls independently;
+4. preserves completed source evidence when another source fails;
+5. writes deterministic JSON, CSV, and Markdown reports.
+
+A run has this layout:
+
+```text
+evals/results/<UTC-run-id>/
+  metadata.json
+  environment.json
+  tools.json
+  manifest.json
+  rubric.csv
+  report.json
+  report.csv
+  report.md
+  sources/
+    <source-id>/
+      upload-response.json
+      view.json
+      result.json
+```
+
+`evals/results/` and `evals/sources/` are gitignored.
+
+## 3. Score the clips
+
+Watch every produced clip and complete the copied `rubric.csv`.
+
+Scores are 1–5:
+
+- `hook`: do the first three seconds earn attention?
+- `standalone`: is the excerpt understandable without episode context?
+- `payoff`: does the excerpt land rather than trail off?
+- `caption_accuracy`: are words correct and synchronized?
+- `framing`: does the crop hold the right speaker without drift?
+- `would_post`: use 5 for yes and 1 for no when possible.
+
+Use `decision_error` only when applicable:
+
+- `false_accept`: the system accepted a clip it should have rejected.
+- `false_reject`: a rejected candidate should have survived.
+
+Record the reviewer and concrete notes. Human ratings are evidence, not an
+objective truth, so reports retain counts and averages rather than inventing an
+AI judge.
+
+Regenerate the report after scoring:
+
+```bash
+python3 evals/report.py evals/results/<run-id>
+```
+
+Compare to a baseline:
+
+```bash
+python3 evals/report.py evals/results/<run-id> \
+  --baseline evals/results/<baseline-run-id> \
+  --thresholds evals/thresholds.json \
+  --enforce
+```
+
+The default gate fails when:
+
+- the current run introduces any new source failure;
+- would-post rate drops by more than 0.05;
+- any average rubric dimension drops by more than 0.25.
+
+The committed `evals/thresholds.json` is the review policy. Change it only in a
+reviewed PR, and do not loosen a gate merely to make a branch pass.
+
+## 4. PR policy
+
+Before merging a change to any of these areas, attach a baseline delta or state
+why the golden set is not applicable:
+
+- `src/select/`
+- `src/validate.rs`
+- `src/frame.rs`
+- `src/captions.rs`
+- `src/transcribe.rs`
+- `src/media.rs`
+- `src/render.rs`
+- `src/pipeline.rs`
+
+A quality-sensitive PR should include:
+
+- baseline and current commit SHAs;
+- source completion rate, source failures, and failed clip renders;
+- ready/accepted/rejected counts;
+- duplicate/overlap rejection rate;
+- would-post rate and rubric averages;
+- false accepts and false rejects;
+- material output examples or reviewer notes;
+- an explicit explanation for every regression.
+
+No source media, model, transcript text, absolute local path, or rendered clip
+should be committed.
+
+## CI coverage
+
+GitHub Actions runs:
+
+```bash
+cargo fmt --all --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+bash -n evals/run.sh
+python3 -m py_compile evals/report.py
+python3 -m unittest discover -s evals/tests -v
+```
+
+CI uses only deterministic synthetic fixtures. It never downloads Whisper
+models or copyrighted media and never pretends to judge creative quality.

--- a/evals/README.md
+++ b/evals/README.md
@@ -66,7 +66,7 @@ The runner:
 1. verifies the studio and manifest;
 2. snapshots commit, branch, tool versions, platform, safe environment checks, and manifest hash;
 3. uploads each source only to the fixed loopback studio at `127.0.0.1:4571` and polls independently;
-4. preserves completed source evidence when another source fails;
+4. copies the full local selection report for exact rejection metrics and preserves completed evidence when another source fails;
 5. writes deterministic JSON, CSV, and Markdown reports.
 
 A run has this layout:
@@ -85,6 +85,7 @@ evals/results/<UTC-run-id>/
     <source-id>/
       upload-response.json
       view.json
+      selection.json
       result.json
 ```
 

--- a/evals/manifest.example.json
+++ b/evals/manifest.example.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "sources": [
+    {
+      "id": "interview-clean",
+      "path": "sources/interview-clean.mp4",
+      "category": "two_person_interview",
+      "description": "Clean two-person interview; happy path for selection, captions, and single-speaker framing.",
+      "tags": [
+        "clean-audio",
+        "two-person"
+      ]
+    },
+    {
+      "id": "solo-monologue",
+      "path": "sources/solo-monologue.mp4",
+      "category": "solo_monologue",
+      "description": "Solo source that stresses ranking without conversational reactions.",
+      "tags": [
+        "solo"
+      ]
+    },
+    {
+      "id": "panel",
+      "path": "sources/panel.mp4",
+      "category": "panel",
+      "description": "Three or more visible speakers; stresses blur-pad fallback and crosstalk.",
+      "tags": [
+        "multi-speaker",
+        "crosstalk"
+      ]
+    },
+    {
+      "id": "noisy-room",
+      "path": "sources/noisy-room.mp4",
+      "category": "noisy_audio",
+      "description": "Room tone or noisy recording; stresses transcription confidence and caption accuracy.",
+      "tags": [
+        "noise"
+      ]
+    },
+    {
+      "id": "fast-accented",
+      "path": "sources/fast-accented.mp4",
+      "category": "fast_or_accented_speech",
+      "description": "Fast or accented speech; stresses word timestamps and faithful quote matching.",
+      "tags": [
+        "fast-speech",
+        "accent"
+      ]
+    },
+    {
+      "id": "target-content",
+      "path": "sources/target-content.mp4",
+      "category": "target_distribution",
+      "description": "A representative source from the content distribution Clipping Factory is intended to ship.",
+      "tags": [
+        "representative"
+      ]
+    }
+  ]
+}

--- a/evals/report.py
+++ b/evals/report.py
@@ -33,8 +33,8 @@ def status(result: dict[str, Any], view: dict[str, Any]) -> str:
     return str(result.get("status") or project.get("status") or "unknown")
 
 
-def ready(view: dict[str, Any]) -> int:
-    return sum(1 for clip in as_list(view.get("clips")) if isinstance(clip, dict) and clip.get("status") == "ready")
+def clip_count(view: dict[str, Any], wanted: str) -> int:
+    return sum(1 for clip in as_list(view.get("clips")) if isinstance(clip, dict) and clip.get("status") == wanted)
 
 
 def accepted(view: dict[str, Any]) -> int:
@@ -54,6 +54,11 @@ def rejected_entries(view: dict[str, Any]) -> list[Any]:
     if isinstance(report, dict):
         return as_list(report.get("rejected"))
     return []
+
+
+def rejected_count(view: dict[str, Any]) -> int:
+    value = view.get("rejected")
+    return max(value, 0) if isinstance(value, int) else len(rejected_entries(view))
 
 
 def rejection_text(item: Any) -> str:
@@ -87,9 +92,10 @@ def load_sources(run_dir: Path) -> list[dict[str, Any]]:
             "source_id": str(result.get("source_id") or folder.name),
             "category": str(result.get("category") or "unspecified"),
             "status": status(result, view),
-            "ready_clips": ready(view),
+            "ready_clips": clip_count(view, "ready"),
+            "failed_clips": clip_count(view, "failed"),
             "accepted_candidates": accepted(view),
-            "rejected_candidates": len(rejects),
+            "rejected_candidates": rejected_count(view),
             "duplicate_rejections": sum(1 for x in rejects if any(t in rejection_text(x).lower() for t in ("overlap", "duplicate"))),
             "selector": str(view.get("selector") or "unknown"),
             "duration_seconds": result.get("duration_seconds"),
@@ -159,7 +165,9 @@ def aggregate(run_dir: Path) -> dict[str, Any]:
         "completed_sources": states["complete"],
         "failed_sources": states["failed"],
         "cancelled_sources": states["cancelled"],
+        "completion_rate": round(states["complete"] / len(sources), 3) if sources else None,
         "ready_clips": sum(s["ready_clips"] for s in sources),
+        "failed_clips": sum(s["failed_clips"] for s in sources),
         "accepted_candidates": sum(s["accepted_candidates"] for s in sources),
         "rejected_candidates": sum(s["rejected_candidates"] for s in sources),
         "duplicate_rejections": duplicates,
@@ -179,10 +187,11 @@ def compare(current: dict[str, Any], baseline: dict[str, Any], thresholds: dict[
     policy = DEFAULTS | (thresholds or {})
     reasons: list[str] = []
     warnings: list[str] = []
-    co, bo = current["operational"], baseline["operational"]
-    new_failures = max(int(co["failed_sources"]) - int(bo["failed_sources"]), 0)
-    if new_failures > int(policy["max_new_source_failures"]):
-        reasons.append(f"new source failures: {new_failures}")
+    baseline_failed = {s["source_id"] for s in baseline["sources"] if s["status"] == "failed"}
+    current_failed = {s["source_id"] for s in current["sources"] if s["status"] == "failed"}
+    new_failed_ids = sorted(current_failed - baseline_failed)
+    if len(new_failed_ids) > int(policy["max_new_source_failures"]):
+        reasons.append(f"new source failures: {', '.join(new_failed_ids)}")
     cr, br = current["human_review"], baseline["human_review"]
     if cr["would_post_rate"] is not None and br["would_post_rate"] is not None:
         drop = round(float(br["would_post_rate"]) - float(cr["would_post_rate"]), 3)
@@ -208,7 +217,7 @@ def md_cell(value: Any) -> str:
 def render_md(report: dict[str, Any]) -> str:
     run, op, review = report["run"], report["operational"], report["human_review"]
     lines = [f"# Clipping Factory eval — {md_cell(run.get('run_id'))}", "", f"- Commit: `{md_cell(run.get('git_commit'))}`", f"- Branch: `{md_cell(run.get('git_branch'))}`", "", "## Operational", "", "| Metric | Value |", "|---|---:|"]
-    for key in ("source_count", "completed_sources", "failed_sources", "ready_clips", "accepted_candidates", "rejected_candidates", "duplicate_rate", "total_duration_seconds"):
+    for key in ("source_count", "completed_sources", "completion_rate", "failed_sources", "ready_clips", "failed_clips", "accepted_candidates", "rejected_candidates", "duplicate_rate", "total_duration_seconds"):
         lines.append(f"| {key} | {md_cell(op.get(key))} |")
     lines += ["", "## Human review", "", f"- Clips reviewed: {review['clips_reviewed']}", f"- Would-post rate: {md_cell(review['would_post_rate'])}", f"- False accepts / rejects: {review['false_accepts']} / {review['false_rejects']}"]
     for field, value in review["score_averages"].items():
@@ -218,9 +227,9 @@ def render_md(report: dict[str, Any]) -> str:
         lines += ["", "## Baseline gate", "", f"**{str(comparison['status']).upper()}**"]
         lines += [f"- {reason}" for reason in comparison["failure_reasons"]]
         lines += [f"- Warning: {warning}" for warning in comparison["warnings"]]
-    lines += ["", "## Source results", "", "| Source | Category | Status | Ready | Rejected | Selector | Error |", "|---|---|---|---:|---:|---|---|"]
+    lines += ["", "## Source results", "", "| Source | Category | Status | Ready | Failed clips | Rejected | Selector | Error |", "|---|---|---|---:|---:|---:|---|---|"]
     for source in report["sources"]:
-        lines.append("| {source_id} | {category} | {status} | {ready_clips} | {rejected_candidates} | {selector} | {error} |".format(**{k: md_cell(v) for k, v in source.items()}))
+        lines.append("| {source_id} | {category} | {status} | {ready_clips} | {failed_clips} | {rejected_candidates} | {selector} | {error} |".format(**{k: md_cell(v) for k, v in source.items()}))
     if review["invalid_rows"]:
         lines += ["", f"> Invalid rubric rows ignored: {', '.join(map(str, review['invalid_rows']))}"]
     return "\n".join(lines) + "\n"
@@ -228,8 +237,8 @@ def render_md(report: dict[str, Any]) -> str:
 
 def render_csv(report: dict[str, Any]) -> str:
     op, review = report["operational"], report["human_review"]
-    fields = ["run_id", "git_commit", "source_count", "completed_sources", "failed_sources", "ready_clips", "accepted_candidates", "rejected_candidates", "duplicate_rate", "clips_reviewed", "would_post_rate", "gate_status"]
-    row = {"run_id": report["run"].get("run_id"), "git_commit": report["run"].get("git_commit"), **{k: op.get(k) for k in fields}, "clips_reviewed": review["clips_reviewed"], "would_post_rate": review["would_post_rate"], "gate_status": (report.get("comparison") or {}).get("status")}
+    fields = ["run_id", "git_commit", "source_count", "completed_sources", "completion_rate", "failed_sources", "ready_clips", "failed_clips", "accepted_candidates", "rejected_candidates", "duplicate_rate", "clips_reviewed", "would_post_rate", "gate_status"]
+    row = {"run_id": report["run"].get("run_id"), "git_commit": report["run"].get("git_commit"), **{k: op.get(k) for k in fields if k in op}, "clips_reviewed": review["clips_reviewed"], "would_post_rate": review["would_post_rate"], "gate_status": (report.get("comparison") or {}).get("status")}
     from io import StringIO
     out = StringIO(newline="")
     writer = csv.DictWriter(out, fieldnames=fields, lineterminator="\n")

--- a/evals/report.py
+++ b/evals/report.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Create deterministic JSON, CSV, and Markdown summaries for local eval runs."""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+SCORES = ("hook_1to5", "standalone_1to5", "payoff_1to5", "caption_accuracy_1to5", "framing_1to5", "would_post_1to5")
+DEFAULTS = {"max_new_source_failures": 0, "max_would_post_rate_drop": 0.05, "max_average_score_drop": 0.25}
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"cannot read {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"{path} must contain a JSON object")
+    return value
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def status(result: dict[str, Any], view: dict[str, Any]) -> str:
+    project = view.get("project") if isinstance(view.get("project"), dict) else {}
+    return str(result.get("status") or project.get("status") or "unknown")
+
+
+def ready(view: dict[str, Any]) -> int:
+    return sum(1 for clip in as_list(view.get("clips")) if isinstance(clip, dict) and clip.get("status") == "ready")
+
+
+def accepted(view: dict[str, Any]) -> int:
+    value = view.get("accepted")
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, list):
+        return len(value)
+    return len(as_list(view.get("clips")))
+
+
+def rejected_entries(view: dict[str, Any]) -> list[Any]:
+    value = view.get("rejected")
+    if isinstance(value, list):
+        return value
+    report = view.get("selection_report")
+    if isinstance(report, dict):
+        return as_list(report.get("rejected"))
+    return []
+
+
+def rejection_text(item: Any) -> str:
+    if isinstance(item, str):
+        return item
+    if isinstance(item, dict):
+        parts: list[str] = []
+        for key in ("reason", "reasons", "rule", "message", "detail"):
+            value = item.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+            elif isinstance(value, list):
+                parts.extend(str(v) for v in value)
+        return " ".join(parts)
+    return str(item)
+
+
+def load_sources(run_dir: Path) -> list[dict[str, Any]]:
+    output: list[dict[str, Any]] = []
+    root = run_dir / "sources"
+    if not root.is_dir():
+        return output
+    for folder in sorted(p for p in root.iterdir() if p.is_dir()):
+        result_path = folder / "result.json"
+        if not result_path.exists():
+            continue
+        result = read_json(result_path)
+        view = read_json(folder / "view.json") if (folder / "view.json").exists() else {}
+        rejects = rejected_entries(view)
+        output.append({
+            "source_id": str(result.get("source_id") or folder.name),
+            "category": str(result.get("category") or "unspecified"),
+            "status": status(result, view),
+            "ready_clips": ready(view),
+            "accepted_candidates": accepted(view),
+            "rejected_candidates": len(rejects),
+            "duplicate_rejections": sum(1 for x in rejects if any(t in rejection_text(x).lower() for t in ("overlap", "duplicate"))),
+            "selector": str(view.get("selector") or "unknown"),
+            "duration_seconds": result.get("duration_seconds"),
+            "error": result.get("error"),
+        })
+    return output
+
+
+def load_rubric(path: Path) -> dict[str, Any]:
+    sums = Counter()
+    counts = Counter()
+    reviewed = would_post = false_accepts = false_rejects = 0
+    invalid_rows: list[int] = []
+    if not path.exists():
+        return {"clips_reviewed": 0, "would_post_count": 0, "would_post_rate": None, "score_averages": {}, "false_accepts": 0, "false_rejects": 0, "invalid_rows": []}
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row_number, row in enumerate(csv.DictReader(handle), start=2):
+            if not any((row.get(field) or "").strip() for field in SCORES):
+                continue
+            parsed: dict[str, float] = {}
+            valid = True
+            for field in SCORES:
+                text = (row.get(field) or "").strip()
+                if not text:
+                    continue
+                try:
+                    value = float(text)
+                except ValueError:
+                    valid = False
+                    break
+                if not 1 <= value <= 5:
+                    valid = False
+                    break
+                parsed[field] = value
+            if not valid or not parsed:
+                invalid_rows.append(row_number)
+                continue
+            reviewed += 1
+            for field, value in parsed.items():
+                sums[field] += value
+                counts[field] += 1
+            if parsed.get("would_post_1to5", 0) >= 4:
+                would_post += 1
+            error = (row.get("decision_error") or "").strip().lower()
+            false_accepts += error == "false_accept"
+            false_rejects += error == "false_reject"
+    averages = {field: round(sums[field] / counts[field], 3) for field in SCORES if counts[field]}
+    return {
+        "clips_reviewed": reviewed,
+        "would_post_count": would_post,
+        "would_post_rate": round(would_post / reviewed, 3) if reviewed else None,
+        "score_averages": averages,
+        "false_accepts": false_accepts,
+        "false_rejects": false_rejects,
+        "invalid_rows": invalid_rows,
+    }
+
+
+def aggregate(run_dir: Path) -> dict[str, Any]:
+    metadata = read_json(run_dir / "metadata.json")
+    sources = load_sources(run_dir)
+    total_candidates = sum(s["accepted_candidates"] + s["rejected_candidates"] for s in sources)
+    duplicates = sum(s["duplicate_rejections"] for s in sources)
+    states = Counter(s["status"] for s in sources)
+    operational = {
+        "source_count": len(sources),
+        "completed_sources": states["complete"],
+        "failed_sources": states["failed"],
+        "cancelled_sources": states["cancelled"],
+        "ready_clips": sum(s["ready_clips"] for s in sources),
+        "accepted_candidates": sum(s["accepted_candidates"] for s in sources),
+        "rejected_candidates": sum(s["rejected_candidates"] for s in sources),
+        "duplicate_rejections": duplicates,
+        "duplicate_rate": round(duplicates / total_candidates, 3) if total_candidates else None,
+        "total_duration_seconds": round(sum(float(s["duration_seconds"]) for s in sources if isinstance(s["duration_seconds"], (int, float))), 3),
+        "selector_counts": dict(sorted(Counter(s["selector"] for s in sources).items())),
+        "category_counts": dict(sorted(Counter(s["category"] for s in sources).items())),
+    }
+    return {"schema_version": 1, "run": metadata, "operational": operational, "human_review": load_rubric(run_dir / "rubric.csv"), "sources": sources}
+
+
+def load_report(path: Path) -> dict[str, Any]:
+    return read_json(path / "report.json") if path.is_dir() and (path / "report.json").exists() else aggregate(path) if path.is_dir() else read_json(path)
+
+
+def compare(current: dict[str, Any], baseline: dict[str, Any], thresholds: dict[str, Any] | None = None) -> dict[str, Any]:
+    policy = DEFAULTS | (thresholds or {})
+    reasons: list[str] = []
+    warnings: list[str] = []
+    co, bo = current["operational"], baseline["operational"]
+    new_failures = max(int(co["failed_sources"]) - int(bo["failed_sources"]), 0)
+    if new_failures > int(policy["max_new_source_failures"]):
+        reasons.append(f"new source failures: {new_failures}")
+    cr, br = current["human_review"], baseline["human_review"]
+    if cr["would_post_rate"] is not None and br["would_post_rate"] is not None:
+        drop = round(float(br["would_post_rate"]) - float(cr["would_post_rate"]), 3)
+        if drop > float(policy["max_would_post_rate_drop"]):
+            reasons.append(f"would-post rate dropped by {drop:.3f}")
+    else:
+        warnings.append("would-post comparison unavailable until both runs are reviewed")
+    for field, baseline_value in br["score_averages"].items():
+        current_value = cr["score_averages"].get(field)
+        if current_value is None:
+            warnings.append(f"{field} comparison unavailable")
+            continue
+        drop = round(float(baseline_value) - float(current_value), 3)
+        if drop > float(policy["max_average_score_drop"]):
+            reasons.append(f"{field} average dropped by {drop:.3f}")
+    return {"status": "fail" if reasons else "pass", "baseline_run_id": baseline["run"].get("run_id"), "thresholds": policy, "failure_reasons": reasons, "warnings": warnings}
+
+
+def md_cell(value: Any) -> str:
+    return str(value if value not in (None, "") else "—").replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def render_md(report: dict[str, Any]) -> str:
+    run, op, review = report["run"], report["operational"], report["human_review"]
+    lines = [f"# Clipping Factory eval — {md_cell(run.get('run_id'))}", "", f"- Commit: `{md_cell(run.get('git_commit'))}`", f"- Branch: `{md_cell(run.get('git_branch'))}`", "", "## Operational", "", "| Metric | Value |", "|---|---:|"]
+    for key in ("source_count", "completed_sources", "failed_sources", "ready_clips", "accepted_candidates", "rejected_candidates", "duplicate_rate", "total_duration_seconds"):
+        lines.append(f"| {key} | {md_cell(op.get(key))} |")
+    lines += ["", "## Human review", "", f"- Clips reviewed: {review['clips_reviewed']}", f"- Would-post rate: {md_cell(review['would_post_rate'])}", f"- False accepts / rejects: {review['false_accepts']} / {review['false_rejects']}"]
+    for field, value in review["score_averages"].items():
+        lines.append(f"- {field}: {value}")
+    comparison = report.get("comparison")
+    if isinstance(comparison, dict):
+        lines += ["", "## Baseline gate", "", f"**{str(comparison['status']).upper()}**"]
+        lines += [f"- {reason}" for reason in comparison["failure_reasons"]]
+        lines += [f"- Warning: {warning}" for warning in comparison["warnings"]]
+    lines += ["", "## Source results", "", "| Source | Category | Status | Ready | Rejected | Selector | Error |", "|---|---|---|---:|---:|---|---|"]
+    for source in report["sources"]:
+        lines.append("| {source_id} | {category} | {status} | {ready_clips} | {rejected_candidates} | {selector} | {error} |".format(**{k: md_cell(v) for k, v in source.items()}))
+    if review["invalid_rows"]:
+        lines += ["", f"> Invalid rubric rows ignored: {', '.join(map(str, review['invalid_rows']))}"]
+    return "\n".join(lines) + "\n"
+
+
+def render_csv(report: dict[str, Any]) -> str:
+    op, review = report["operational"], report["human_review"]
+    fields = ["run_id", "git_commit", "source_count", "completed_sources", "failed_sources", "ready_clips", "accepted_candidates", "rejected_candidates", "duplicate_rate", "clips_reviewed", "would_post_rate", "gate_status"]
+    row = {"run_id": report["run"].get("run_id"), "git_commit": report["run"].get("git_commit"), **{k: op.get(k) for k in fields}, "clips_reviewed": review["clips_reviewed"], "would_post_rate": review["would_post_rate"], "gate_status": (report.get("comparison") or {}).get("status")}
+    from io import StringIO
+    out = StringIO(newline="")
+    writer = csv.DictWriter(out, fieldnames=fields, lineterminator="\n")
+    writer.writeheader(); writer.writerow({k: "" if row.get(k) is None else row.get(k) for k in fields})
+    return out.getvalue()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("run_dir", type=Path)
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--thresholds", type=Path)
+    parser.add_argument("--output-json", type=Path)
+    parser.add_argument("--output-md", type=Path)
+    parser.add_argument("--output-csv", type=Path)
+    parser.add_argument("--enforce", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        report = aggregate(args.run_dir.resolve())
+        if args.baseline:
+            policy = read_json(args.thresholds) if args.thresholds else None
+            report["comparison"] = compare(report, load_report(args.baseline.resolve()), policy)
+        json_path = args.output_json or args.run_dir / "report.json"
+        md_path = args.output_md or args.run_dir / "report.md"
+        csv_path = args.output_csv or args.run_dir / "report.csv"
+        for path in (json_path, md_path, csv_path):
+            path.parent.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        md_path.write_text(render_md(report), encoding="utf-8")
+        csv_path.write_text(render_csv(report), encoding="utf-8")
+    except RuntimeError as exc:
+        print(f"eval report error: {exc}", file=sys.stderr)
+        return 1
+    print(f"Wrote {json_path}, {csv_path}, and {md_path}")
+    return 2 if args.enforce and (report.get("comparison") or {}).get("status") == "fail" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/report.py
+++ b/evals/report.py
@@ -87,17 +87,19 @@ def load_sources(run_dir: Path) -> list[dict[str, Any]]:
             continue
         result = read_json(result_path)
         view = read_json(folder / "view.json") if (folder / "view.json").exists() else {}
-        rejects = rejected_entries(view)
+        selection = read_json(folder / "selection.json") if (folder / "selection.json").exists() else {}
+        evidence = selection or view
+        rejects = rejected_entries(evidence)
         output.append({
             "source_id": str(result.get("source_id") or folder.name),
             "category": str(result.get("category") or "unspecified"),
             "status": status(result, view),
             "ready_clips": clip_count(view, "ready"),
             "failed_clips": clip_count(view, "failed"),
-            "accepted_candidates": accepted(view),
-            "rejected_candidates": rejected_count(view),
+            "accepted_candidates": accepted(evidence),
+            "rejected_candidates": rejected_count(evidence),
             "duplicate_rejections": sum(1 for x in rejects if any(t in rejection_text(x).lower() for t in ("overlap", "duplicate"))),
-            "selector": str(view.get("selector") or "unknown"),
+            "selector": str(selection.get("selector") or view.get("selector") or "unknown"),
             "duration_seconds": result.get("duration_seconds"),
             "error": result.get("error"),
         })

--- a/evals/rubric.csv
+++ b/evals/rubric.csv
@@ -1,1 +1,1 @@
-source,clip_rank,headline,hook_1to5,standalone_1to5,payoff_1to5,caption_accuracy_1to5,framing_1to5,would_post_1to5,notes
+source,clip_rank,headline,hook_1to5,standalone_1to5,payoff_1to5,caption_accuracy_1to5,framing_1to5,would_post_1to5,decision_error,reviewer,notes

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -1,48 +1,128 @@
 #!/usr/bin/env bash
-# Run every MP4 in evals/sources/ through a running Clipping Factory studio
-# and collect the resulting project views for scoring.
-#
-# Usage:  bash evals/run.sh [host]        (default http://localhost:4571)
-set -euo pipefail
+# Run a private local golden set through the real Clipping Factory HTTP path.
+set -uo pipefail
 
-HOST="${1:-http://localhost:4571}"
 ROOT="$(cd "$(dirname "$0")" && pwd)"
-SOURCES="$ROOT/sources"
-RUN_DIR="$ROOT/results/$(date +%Y%m%d-%H%M%S)"
+HOST="http://127.0.0.1:4571"
+MANIFEST="$ROOT/manifest.json"
+RUN_DIR=""
+BASELINE=""
+THRESHOLDS="$ROOT/thresholds.json"
+POLL=5
+TIMEOUT=21600
+RESUME=false
+ENFORCE=false
 
-command -v jq >/dev/null || { echo "jq is required (brew install jq)"; exit 1; }
-curl -sf "$HOST/api/setup" >/dev/null || { echo "Studio not reachable at $HOST — start it with: cargo run --release"; exit 1; }
-shopt -s nullglob
-mp4s=("$SOURCES"/*.mp4 "$SOURCES"/*.m4v)
-[ ${#mp4s[@]} -gt 0 ] || { echo "No MP4s in $SOURCES — add golden-set episodes first (see evals/README.md)"; exit 1; }
+usage() {
+  cat <<'EOF'
+Usage: bash evals/run.sh [options]
+  --manifest PATH        Local manifest (default evals/manifest.json)
+  --run-dir PATH         Result directory (default evals/results/<UTC id>)
+  --baseline PATH        Baseline run directory or report.json
+  --thresholds PATH      Gate policy JSON
+  --poll-seconds N       Poll interval (default 5)
+  --timeout-seconds N    Per-source timeout (default 21600)
+  --resume               Skip sources with terminal result.json
+  --enforce              Exit 2 when baseline thresholds fail
+EOF
+}
 
-mkdir -p "$RUN_DIR"
-echo "Eval run → $RUN_DIR (${#mp4s[@]} source(s))"
-
-for src in "${mp4s[@]}"; do
-  name="$(basename "$src")"
-  echo ""
-  echo "── $name"
-  id="$(curl -sf -X POST "$HOST/api/projects" -F "file=@$src" | jq -r '.project.id')"
-  echo "   project $id — processing…"
-
-  status="created"
-  while :; do
-    sleep 5
-    view="$(curl -sf "$HOST/api/projects/$id")"
-    status="$(jq -r '.project.status' <<<"$view")"
-    case "$status" in
-      complete|failed|cancelled) break ;;
-      *) printf '   %s\r' "$status" ;;
-    esac
-  done
-
-  out="$RUN_DIR/${name%.*}"
-  mkdir -p "$out"
-  jq . <<<"$view" > "$out/view.json"
-  jq -r '"   → \(.project.status): \(.clips | map(select(.status=="ready")) | length) clip(s) ready, \(.rejected) rejected candidate(s), selector: \(.selector // "n/a")"' <<<"$view"
+while (($#)); do
+  case "$1" in
+    --manifest) MANIFEST="$2"; shift 2 ;;
+    --run-dir) RUN_DIR="$2"; shift 2 ;;
+    --baseline) BASELINE="$2"; shift 2 ;;
+    --thresholds) THRESHOLDS="$2"; shift 2 ;;
+    --poll-seconds) POLL="$2"; shift 2 ;;
+    --timeout-seconds) TIMEOUT="$2"; shift 2 ;;
+    --resume) RESUME=true; shift ;;
+    --enforce) ENFORCE=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 1 ;;
+  esac
 done
 
-cp "$ROOT/rubric.csv" "$RUN_DIR/rubric.csv"
-echo ""
-echo "Done. Watch every clip, then score $RUN_DIR/rubric.csv (see evals/README.md)."
+for cmd in curl jq python3; do command -v "$cmd" >/dev/null || { echo "$cmd is required" >&2; exit 1; }; done
+[[ -f "$MANIFEST" ]] || { echo "Missing $MANIFEST; copy evals/manifest.example.json and edit local paths." >&2; exit 1; }
+curl -sf "$HOST/api/setup" >/dev/null || { echo "Studio not reachable at $HOST; run cargo run --release." >&2; exit 1; }
+
+MANIFEST="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$MANIFEST")"
+MANIFEST_DIR="$(dirname "$MANIFEST")"
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)"
+RUN_DIR="${RUN_DIR:-$ROOT/results/$RUN_ID}"
+if [[ -e "$RUN_DIR" && "$RESUME" != true ]]; then echo "$RUN_DIR already exists; use --resume or another --run-dir" >&2; exit 1; fi
+mkdir -p "$RUN_DIR/sources"
+
+python3 - "$MANIFEST" <<'PY'
+import json,re,sys
+p=sys.argv[1]; data=json.load(open(p,encoding='utf-8'))
+if data.get('schema_version') != 1: raise SystemExit('manifest schema_version must be 1')
+items=data.get('sources')
+if not isinstance(items,list) or not items: raise SystemExit('manifest sources must be a non-empty list')
+seen=set()
+for item in items:
+    sid=item.get('id'); path=item.get('path')
+    if not isinstance(sid,str) or not re.fullmatch(r'[A-Za-z0-9][A-Za-z0-9._-]{0,79}',sid): raise SystemExit(f'invalid source id: {sid!r}')
+    if sid in seen: raise SystemExit(f'duplicate source id: {sid}')
+    if not isinstance(path,str) or not path: raise SystemExit(f'missing path for {sid}')
+    seen.add(sid)
+PY
+
+cp "$MANIFEST" "$RUN_DIR/manifest.json"
+cp "$ROOT/rubric.csv" "$RUN_DIR/rubric.csv" 2>/dev/null || true
+STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+BRANCH="$(git branch --show-current 2>/dev/null || echo unknown)"
+DIRTY=false; git diff --quiet --ignore-submodules HEAD 2>/dev/null || DIRTY=true
+python3 - "$RUN_DIR/metadata.json" "$RUN_ID" "$STARTED" "$COMMIT" "$BRANCH" "$DIRTY" <<'PY'
+import json,platform,sys
+path,run_id,started,commit,branch,dirty=sys.argv[1:]
+json.dump({'schema_version':1,'run_id':run_id,'started_at':started,'git_commit':commit,'git_branch':branch,'git_dirty':dirty=='true','platform':platform.platform(),'python':platform.python_version()},open(path,'w',encoding='utf-8'),indent=2,sort_keys=True); open(path,'a').write('\n')
+PY
+# Store only booleans/numbers from setup. Paths and transcript/provider secrets are excluded.
+curl -sf "$HOST/api/setup" | jq '{ffmpeg,ffmpeg_ass,ffprobe,whisper_ok,model_ok,model_mb,face_model_ok,disk_free_gb}' > "$RUN_DIR/environment.json"
+
+SOURCE_COUNT="$(jq '.sources | length' "$MANIFEST")"
+for ((i=0; i<SOURCE_COUNT; i++)); do
+  ID="$(jq -r ".sources[$i].id" "$MANIFEST")"
+  REL="$(jq -r ".sources[$i].path" "$MANIFEST")"
+  CATEGORY="$(jq -r ".sources[$i].category // \"unspecified\"" "$MANIFEST")"
+  SRC="$REL"; [[ "$SRC" = /* ]] || SRC="$MANIFEST_DIR/$SRC"
+  OUT="$RUN_DIR/sources/$ID"; mkdir -p "$OUT"
+  if [[ "$RESUME" == true && -f "$OUT/result.json" ]] && jq -e '.status | IN("complete","failed","cancelled")' "$OUT/result.json" >/dev/null; then echo "↷ $ID already terminal"; continue; fi
+  echo "── $ID"
+  if [[ ! -f "$SRC" ]]; then
+    jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg error "source file not found" '{schema_version:1,source_id:$id,category:$cat,status:"failed",error:$error}' > "$OUT/result.json"
+    continue
+  fi
+  UPLOAD="$OUT/upload-response.json"
+  if ! curl -sf -X POST "$HOST/api/projects" -F "file=@$SRC" > "$UPLOAD"; then
+    jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg error "upload failed" '{schema_version:1,source_id:$id,category:$cat,status:"failed",error:$error}' > "$OUT/result.json"; continue
+  fi
+  PROJECT="$(jq -r '.project.id // .id // empty' "$UPLOAD")"
+  if [[ -z "$PROJECT" ]]; then jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg error "upload returned no project id" '{schema_version:1,source_id:$id,category:$cat,status:"failed",error:$error}' > "$OUT/result.json"; continue; fi
+  BEGIN="$(date +%s)"; FAILS=0; FINAL="unknown"; ERROR=""
+  while :; do
+    sleep "$POLL"
+    if curl -sf "$HOST/api/projects/$PROJECT" > "$OUT/view.tmp"; then
+      mv "$OUT/view.tmp" "$OUT/view.json"; FAILS=0
+      FINAL="$(jq -r '.project.status // "unknown"' "$OUT/view.json")"
+      [[ "$FINAL" =~ ^(complete|failed|cancelled)$ ]] && break
+    else
+      FAILS=$((FAILS+1)); [[ $FAILS -ge 3 ]] && { FINAL=failed; ERROR="three consecutive project polling failures"; break; }
+    fi
+    if (( $(date +%s) - BEGIN > TIMEOUT )); then FINAL=failed; ERROR="source timed out after ${TIMEOUT}s"; break; fi
+  done
+  [[ -z "$ERROR" && "$FINAL" == failed ]] && ERROR="$(jq -r '.project.error // .error // "project failed"' "$OUT/view.json" 2>/dev/null || echo project failed)"
+  DURATION="$(( $(date +%s) - BEGIN ))"
+  jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg status "$FINAL" --arg project "$PROJECT" --arg error "$ERROR" --argjson seconds "$DURATION" '{schema_version:1,source_id:$id,category:$cat,status:$status,project_id:$project,duration_seconds:$seconds,error:(if $error=="" then null else $error end)}' > "$OUT/result.json"
+done
+
+python3 - "$RUN_DIR/metadata.json" <<'PY'
+import json,sys,datetime
+p=sys.argv[1]; data=json.load(open(p)); data['completed_at']=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace('+00:00','Z'); json.dump(data,open(p,'w'),indent=2,sort_keys=True); open(p,'a').write('\n')
+PY
+ARGS=("$ROOT/report.py" "$RUN_DIR" --thresholds "$THRESHOLDS")
+[[ -n "$BASELINE" ]] && ARGS+=(--baseline "$BASELINE")
+[[ "$ENFORCE" == true ]] && ARGS+=(--enforce)
+python3 "${ARGS[@]}"

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run a private local golden set through the real Clipping Factory HTTP path.
-set -uo pipefail
+set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")" && pwd)"
 HOST="http://127.0.0.1:4571"
@@ -22,7 +22,7 @@ Usage: bash evals/run.sh [options]
   --thresholds PATH      Gate policy JSON
   --poll-seconds N       Poll interval (default 5)
   --timeout-seconds N    Per-source timeout (default 21600)
-  --resume               Skip sources with terminal result.json
+  --resume               Skip completed sources and retry unfinished/failed ones
   --enforce              Exit 2 when baseline thresholds fail
 EOF
 }
@@ -68,19 +68,31 @@ for item in items:
     seen.add(sid)
 PY
 
-cp "$MANIFEST" "$RUN_DIR/manifest.json"
-cp "$ROOT/rubric.csv" "$RUN_DIR/rubric.csv" 2>/dev/null || true
-STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
-BRANCH="$(git branch --show-current 2>/dev/null || echo unknown)"
-DIRTY=false; git diff --quiet --ignore-submodules HEAD 2>/dev/null || DIRTY=true
-python3 - "$RUN_DIR/metadata.json" "$RUN_ID" "$STARTED" "$COMMIT" "$BRANCH" "$DIRTY" <<'PY'
-import json,platform,sys
-path,run_id,started,commit,branch,dirty=sys.argv[1:]
-json.dump({'schema_version':1,'run_id':run_id,'started_at':started,'git_commit':commit,'git_branch':branch,'git_dirty':dirty=='true','platform':platform.platform(),'python':platform.python_version()},open(path,'w',encoding='utf-8'),indent=2,sort_keys=True); open(path,'a').write('\n')
+if [[ "$RESUME" == true && -f "$RUN_DIR/metadata.json" ]]; then
+  RUN_ID="$(jq -r '.run_id' "$RUN_DIR/metadata.json")"
+else
+  cp "$MANIFEST" "$RUN_DIR/manifest.json"
+  cp "$ROOT/rubric.csv" "$RUN_DIR/rubric.csv" 2>/dev/null || true
+  STARTED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  COMMIT="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+  BRANCH="$(git branch --show-current 2>/dev/null || echo unknown)"
+  DIRTY=false; git diff --quiet --ignore-submodules HEAD 2>/dev/null || DIRTY=true
+  python3 - "$RUN_DIR/metadata.json" "$RUN_ID" "$STARTED" "$COMMIT" "$BRANCH" "$DIRTY" "$MANIFEST" <<'PY'
+import hashlib,json,platform,sys
+path,run_id,started,commit,branch,dirty,manifest=sys.argv[1:]
+data={'schema_version':1,'run_id':run_id,'started_at':started,'git_commit':commit,'git_branch':branch,'git_dirty':dirty=='true','platform':platform.platform(),'python':platform.python_version(),'manifest_sha256':hashlib.sha256(open(manifest,'rb').read()).hexdigest()}
+json.dump(data,open(path,'w',encoding='utf-8'),indent=2,sort_keys=True); open(path,'a').write('\n')
 PY
-# Store only booleans/numbers from setup. Paths and transcript/provider secrets are excluded.
-curl -sf "$HOST/api/setup" | jq '{ffmpeg,ffmpeg_ass,ffprobe,whisper_ok,model_ok,model_mb,face_model_ok,disk_free_gb}' > "$RUN_DIR/environment.json"
+  python3 - "$RUN_DIR/tools.json" <<'PY'
+import json,subprocess,sys
+def version(*cmd):
+    try: return subprocess.run(cmd,text=True,stdout=subprocess.PIPE,stderr=subprocess.STDOUT,check=False).stdout.splitlines()[0]
+    except (OSError,IndexError): return 'unavailable'
+json.dump({'rustc':version('rustc','--version'),'cargo':version('cargo','--version'),'ffmpeg':version('ffmpeg','-version'),'ffprobe':version('ffprobe','-version'),'jq':version('jq','--version')},open(sys.argv[1],'w'),indent=2,sort_keys=True); open(sys.argv[1],'a').write('\n')
+PY
+  # Store only booleans/numbers from setup. Paths and transcript/provider secrets are excluded.
+  curl -sf "$HOST/api/setup" | jq '{ffmpeg,ffmpeg_ass,ffprobe,whisper_ok,model_ok,model_mb,face_model_ok,disk_free_gb}' > "$RUN_DIR/environment.json"
+fi
 
 SOURCE_COUNT="$(jq '.sources | length' "$MANIFEST")"
 for ((i=0; i<SOURCE_COUNT; i++)); do
@@ -89,19 +101,20 @@ for ((i=0; i<SOURCE_COUNT; i++)); do
   CATEGORY="$(jq -r ".sources[$i].category // \"unspecified\"" "$MANIFEST")"
   SRC="$REL"; [[ "$SRC" = /* ]] || SRC="$MANIFEST_DIR/$SRC"
   OUT="$RUN_DIR/sources/$ID"; mkdir -p "$OUT"
-  if [[ "$RESUME" == true && -f "$OUT/result.json" ]] && jq -e '.status | IN("complete","failed","cancelled")' "$OUT/result.json" >/dev/null; then echo "↷ $ID already terminal"; continue; fi
+  if [[ "$RESUME" == true && -f "$OUT/result.json" ]] && jq -e '.status == "complete"' "$OUT/result.json" >/dev/null; then echo "↷ $ID already complete"; continue; fi
   echo "── $ID"
   if [[ ! -f "$SRC" ]]; then
     jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg error "source file not found" '{schema_version:1,source_id:$id,category:$cat,status:"failed",error:$error}' > "$OUT/result.json"
     continue
   fi
+  BEGIN="$(date +%s)"
   UPLOAD="$OUT/upload-response.json"
   if ! curl -sf -X POST "$HOST/api/projects" -F "file=@$SRC" > "$UPLOAD"; then
     jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg error "upload failed" '{schema_version:1,source_id:$id,category:$cat,status:"failed",error:$error}' > "$OUT/result.json"; continue
   fi
   PROJECT="$(jq -r '.project.id // .id // empty' "$UPLOAD")"
   if [[ -z "$PROJECT" ]]; then jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg error "upload returned no project id" '{schema_version:1,source_id:$id,category:$cat,status:"failed",error:$error}' > "$OUT/result.json"; continue; fi
-  BEGIN="$(date +%s)"; FAILS=0; FINAL="unknown"; ERROR=""
+  FAILS=0; FINAL="unknown"; ERROR=""
   while :; do
     sleep "$POLL"
     if curl -sf "$HOST/api/projects/$PROJECT" > "$OUT/view.tmp"; then
@@ -113,7 +126,7 @@ for ((i=0; i<SOURCE_COUNT; i++)); do
     fi
     if (( $(date +%s) - BEGIN > TIMEOUT )); then FINAL=failed; ERROR="source timed out after ${TIMEOUT}s"; break; fi
   done
-  [[ -z "$ERROR" && "$FINAL" == failed ]] && ERROR="$(jq -r '.project.error // .error // "project failed"' "$OUT/view.json" 2>/dev/null || echo project failed)"
+  if [[ -z "$ERROR" && "$FINAL" == failed ]]; then ERROR="$(jq -r '.project.error // .error // "project failed"' "$OUT/view.json" 2>/dev/null || echo project failed)"; fi
   DURATION="$(( $(date +%s) - BEGIN ))"
   jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg status "$FINAL" --arg project "$PROJECT" --arg error "$ERROR" --argjson seconds "$DURATION" '{schema_version:1,source_id:$id,category:$cat,status:$status,project_id:$project,duration_seconds:$seconds,error:(if $error=="" then null else $error end)}' > "$OUT/result.json"
 done
@@ -123,6 +136,6 @@ import json,sys,datetime
 p=sys.argv[1]; data=json.load(open(p)); data['completed_at']=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace('+00:00','Z'); json.dump(data,open(p,'w'),indent=2,sort_keys=True); open(p,'a').write('\n')
 PY
 ARGS=("$ROOT/report.py" "$RUN_DIR" --thresholds "$THRESHOLDS")
-[[ -n "$BASELINE" ]] && ARGS+=(--baseline "$BASELINE")
-[[ "$ENFORCE" == true ]] && ARGS+=(--enforce)
+if [[ -n "$BASELINE" ]]; then ARGS+=(--baseline "$BASELINE"); fi
+if [[ "$ENFORCE" == true ]]; then ARGS+=(--enforce); fi
 python3 "${ARGS[@]}"

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -44,7 +44,8 @@ done
 
 for cmd in curl jq python3; do command -v "$cmd" >/dev/null || { echo "$cmd is required" >&2; exit 1; }; done
 [[ -f "$MANIFEST" ]] || { echo "Missing $MANIFEST; copy evals/manifest.example.json and edit local paths." >&2; exit 1; }
-curl -sf "$HOST/api/setup" >/dev/null || { echo "Studio not reachable at $HOST; run cargo run --release." >&2; exit 1; }
+SETUP="$(curl -sf "$HOST/api/setup")" || { echo "Studio not reachable at $HOST; run cargo run --release." >&2; exit 1; }
+DATA_DIR="$(jq -r '.data_dir // empty' <<<"$SETUP")"
 
 MANIFEST="$(python3 -c 'import os,sys; print(os.path.abspath(sys.argv[1]))' "$MANIFEST")"
 MANIFEST_DIR="$(dirname "$MANIFEST")"
@@ -91,7 +92,7 @@ def version(*cmd):
 json.dump({'rustc':version('rustc','--version'),'cargo':version('cargo','--version'),'ffmpeg':version('ffmpeg','-version'),'ffprobe':version('ffprobe','-version'),'jq':version('jq','--version')},open(sys.argv[1],'w'),indent=2,sort_keys=True); open(sys.argv[1],'a').write('\n')
 PY
   # Store only booleans/numbers from setup. Paths and transcript/provider secrets are excluded.
-  curl -sf "$HOST/api/setup" | jq '{ffmpeg,ffmpeg_ass,ffprobe,whisper_ok,model_ok,model_mb,face_model_ok,disk_free_gb}' > "$RUN_DIR/environment.json"
+  jq '{ffmpeg,ffmpeg_ass,ffprobe,whisper_ok,model_ok,model_mb,face_model_ok,disk_free_gb}' <<<"$SETUP" > "$RUN_DIR/environment.json"
 fi
 
 SOURCE_COUNT="$(jq '.sources | length' "$MANIFEST")"
@@ -127,6 +128,9 @@ for ((i=0; i<SOURCE_COUNT; i++)); do
     if (( $(date +%s) - BEGIN > TIMEOUT )); then FINAL=failed; ERROR="source timed out after ${TIMEOUT}s"; break; fi
   done
   if [[ -z "$ERROR" && "$FINAL" == failed ]]; then ERROR="$(jq -r '.project.error // .error // "project failed"' "$OUT/view.json" 2>/dev/null || echo project failed)"; fi
+  if [[ -n "$DATA_DIR" && -f "$DATA_DIR/projects/$PROJECT/candidates.json" ]]; then
+    cp "$DATA_DIR/projects/$PROJECT/candidates.json" "$OUT/selection.json"
+  fi
   DURATION="$(( $(date +%s) - BEGIN ))"
   jq -n --arg id "$ID" --arg cat "$CATEGORY" --arg status "$FINAL" --arg project "$PROJECT" --arg error "$ERROR" --argjson seconds "$DURATION" '{schema_version:1,source_id:$id,category:$cat,status:$status,project_id:$project,duration_seconds:$seconds,error:(if $error=="" then null else $error end)}' > "$OUT/result.json"
 done

--- a/evals/tests/fixtures/run_bundle.json
+++ b/evals/tests/fixtures/run_bundle.json
@@ -1,0 +1,93 @@
+{
+  "baseline": {
+    "metadata": {
+      "completed_at": "2026-07-29T10:10:00Z",
+      "git_branch": "agent/clipping-factory-buildout",
+      "git_commit": "aaa111",
+      "run_id": "baseline-001",
+      "schema_version": 1,
+      "started_at": "2026-07-29T10:00:00Z"
+    },
+    "rubric_csv": "source,clip_rank,headline,hook_1to5,standalone_1to5,payoff_1to5,caption_accuracy_1to5,framing_1to5,would_post_1to5,decision_error,reviewer,notes\ninterview-clean,1,Strong opening,5,5,4,5,4,5,,tester,good\ninterview-clean,2,Second clip,4,4,4,4,4,5,,tester,good\npanel,1,Panel clip,4,4,4,4,3,1,false_accept,tester,weak framing\n",
+    "sources": [
+      {
+        "dir": "interview-clean",
+        "result": {
+          "category": "two_person_interview",
+          "duration_seconds": 300.0,
+          "error": null,
+          "schema_version": 1,
+          "source_id": "interview-clean",
+          "status": "complete"
+        },
+        "view": {
+          "accepted": [{"id": "a"}, {"id": "b"}],
+          "clips": [{"status": "ready"}, {"status": "ready"}],
+          "project": {"status": "complete"},
+          "rejected": [{"reason": "overlap with a stronger candidate"}],
+          "selector": "local"
+        }
+      },
+      {
+        "dir": "panel",
+        "result": {
+          "category": "panel",
+          "duration_seconds": 400.0,
+          "error": null,
+          "schema_version": 1,
+          "source_id": "panel",
+          "status": "complete"
+        },
+        "view": {
+          "accepted": [{"id": "c"}],
+          "clips": [{"status": "ready"}],
+          "project": {"status": "complete"},
+          "rejected": [{"reason": "context dependency too high"}],
+          "selector": "local"
+        }
+      }
+    ]
+  },
+  "current": {
+    "metadata": {
+      "completed_at": "2026-07-30T10:12:00Z",
+      "git_branch": "agent/issue-3-real-media-quality-gate",
+      "git_commit": "bbb222",
+      "run_id": "current-002",
+      "schema_version": 1,
+      "started_at": "2026-07-30T10:00:00Z"
+    },
+    "rubric_csv": "source,clip_rank,headline,hook_1to5,standalone_1to5,payoff_1to5,caption_accuracy_1to5,framing_1to5,would_post_1to5,decision_error,reviewer,notes\ninterview-clean,1,Strong opening,4,4,4,4,4,5,,tester,good\ninterview-clean,2,Second clip,3,3,3,3,3,1,false_accept,tester,weak\n",
+    "sources": [
+      {
+        "dir": "interview-clean",
+        "result": {
+          "category": "two_person_interview",
+          "duration_seconds": 320.5,
+          "error": null,
+          "schema_version": 1,
+          "source_id": "interview-clean",
+          "status": "complete"
+        },
+        "view": {
+          "accepted": [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+          "clips": [{"status": "ready"}, {"status": "ready"}, {"status": "failed"}],
+          "project": {"status": "complete"},
+          "rejected": [{"reason": "duplicate interval"}, {"reason": "context dependency too high"}],
+          "selector": "local"
+        }
+      },
+      {
+        "dir": "panel",
+        "result": {
+          "category": "panel",
+          "duration_seconds": 55.25,
+          "error": "render process exited 1",
+          "schema_version": 1,
+          "source_id": "panel",
+          "status": "failed"
+        }
+      }
+    ]
+  }
+}

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+import importlib.util,json,tempfile,unittest,sys
+from pathlib import Path
+
+PATH=Path(__file__).resolve().parents[1]/"report.py"
+SPEC=importlib.util.spec_from_file_location("eval_report",PATH); assert SPEC and SPEC.loader
+mod=importlib.util.module_from_spec(SPEC); sys.modules[SPEC.name]=mod; SPEC.loader.exec_module(mod)
+FIX=Path(__file__).parent/"fixtures"/"run_bundle.json"
+
+def materialize(root:Path,payload:dict)->Path:
+    run=root/payload["metadata"]["run_id"]; (run/"sources").mkdir(parents=True)
+    (run/"metadata.json").write_text(json.dumps(payload["metadata"]),encoding="utf-8")
+    (run/"rubric.csv").write_text(payload["rubric_csv"],encoding="utf-8")
+    for source in payload["sources"]:
+        folder=run/"sources"/source["dir"]; folder.mkdir()
+        (folder/"result.json").write_text(json.dumps(source["result"]),encoding="utf-8")
+        if "view" in source: (folder/"view.json").write_text(json.dumps(source["view"]),encoding="utf-8")
+    return run
+
+class ReportTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls): cls.data=json.loads(FIX.read_text())
+    def test_partial_failure_metrics(self):
+        with tempfile.TemporaryDirectory() as tmp: report=mod.aggregate(materialize(Path(tmp),self.data["current"]))
+        self.assertEqual(report["operational"]["failed_sources"],1)
+        self.assertEqual(report["operational"]["ready_clips"],2)
+        self.assertEqual(report["operational"]["duplicate_rate"],0.2)
+        self.assertEqual(report["human_review"]["would_post_rate"],0.5)
+        self.assertEqual(report["human_review"]["false_accepts"],1)
+    def test_gate_flags_regressions(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp); baseline=mod.aggregate(materialize(root,self.data["baseline"])); current=mod.aggregate(materialize(root,self.data["current"])); gate=mod.compare(current,baseline)
+        self.assertEqual(gate["status"],"fail")
+        self.assertTrue(any("new source failures" in x for x in gate["failure_reasons"]))
+        self.assertTrue(any("would-post" in x for x in gate["failure_reasons"]))
+    def test_cli_is_deterministic(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root=Path(tmp); run=materialize(root,self.data["current"])
+            outputs=[]
+            for prefix in ("a","b"):
+                paths=[root/f"{prefix}.{ext}" for ext in ("json","md","csv")]
+                self.assertEqual(mod.main([str(run),"--output-json",str(paths[0]),"--output-md",str(paths[1]),"--output-csv",str(paths[2])]),0); outputs.append([p.read_bytes() for p in paths])
+        self.assertEqual(outputs[0],outputs[1])
+    def test_invalid_score_is_excluded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path=Path(tmp)/"rubric.csv"; path.write_text("source,hook_1to5,would_post_1to5\nclip,9,5\n")
+            result=mod.load_rubric(path)
+        self.assertEqual(result["clips_reviewed"],0); self.assertEqual(result["invalid_rows"],[2])
+
+if __name__=="__main__": unittest.main()

--- a/evals/tests/test_report.py
+++ b/evals/tests/test_report.py
@@ -41,6 +41,19 @@ class ReportTests(unittest.TestCase):
                 paths=[root/f"{prefix}.{ext}" for ext in ("json","md","csv")]
                 self.assertEqual(mod.main([str(run),"--output-json",str(paths[0]),"--output-md",str(paths[1]),"--output-csv",str(paths[2])]),0); outputs.append([p.read_bytes() for p in paths])
         self.assertEqual(outputs[0],outputs[1])
+    def test_full_selection_overrides_capped_view_summary(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run=materialize(Path(tmp),self.data["current"])
+            folder=run/"sources"/"interview-clean"
+            view=json.loads((folder/"view.json").read_text()); view["rejected"]=2; view.pop("accepted",None); view["rejected_summary"]=[{"reasons":["context dependency"]}]
+            (folder/"view.json").write_text(json.dumps(view))
+            selection={"selector":"local","accepted":[{"rank":1},{"rank":2},{"rank":3}],"rejected":[{"reasons":["duplicate interval"]},{"reasons":["context dependency"]}]}
+            (folder/"selection.json").write_text(json.dumps(selection))
+            report=mod.aggregate(run)
+        source=report["sources"][0]
+        self.assertEqual(source["accepted_candidates"],3)
+        self.assertEqual(source["rejected_candidates"],2)
+        self.assertEqual(source["duplicate_rejections"],1)
     def test_invalid_score_is_excluded(self):
         with tempfile.TemporaryDirectory() as tmp:
             path=Path(tmp)/"rubric.csv"; path.write_text("source,hook_1to5,would_post_1to5\nclip,9,5\n")

--- a/evals/thresholds.json
+++ b/evals/thresholds.json
@@ -1,0 +1,5 @@
+{
+  "max_new_source_failures": 0,
+  "max_would_post_rate_drop": 0.05,
+  "max_average_score_drop": 0.25
+}


### PR DESCRIPTION
## Summary

Implements the automated foundation of issue #3: a local, privacy-preserving quality regression gate for Clipping Factory.

This PR was built as an end-to-end G Stack example using the loop:

1. Office Hours / product interrogation
2. CEO scope review
3. Engineering and developer-experience review
4. Implementation
5. Independent diff review and fixes
6. Deterministic QA
7. Draft ship

The full reasoning artifact is in `docs/agent/GSTACK_ISSUE_3_PLAN.md`.

## What changed

- activates `.github/workflows/ci.yml` for fmt, clippy, Rust tests, shell syntax, Python syntax, and deterministic eval fixtures
- adds a versioned six-slot golden-set manifest example
- upgrades `evals/run.sh` into a resumable, partial-failure-preserving runner
- hard-locks media upload to the loopback studio at `127.0.0.1:4571`
- records commit, branch, dirty state, manifest hash, platform, tool versions, and safe environment checks
- copies the full local validated `candidates.json` into ignored run evidence for exact accepted, rejected, and duplicate metrics
- adds deterministic JSON, CSV, and Markdown aggregation
- reports completion rate, source failures, failed clip renders, accepted/rejected counts, duplicate rate, selector/category counts, and processing duration
- adds human rubric aggregation, would-post rate, false accepts/rejects, and invalid-row reporting
- adds committed baseline thresholds and `--enforce` exit behavior
- adds deterministic fixtures covering partial failure, regression detection, invalid scoring, repeatable output, and full-selection evidence
- documents the local runbook and PR quality policy

## Review fixes applied

- fixed CSV output overwriting run metadata
- compares failed source IDs, not merely failure counts
- counts clip-level render failures separately from source failures
- preserves original run metadata and rubric during resume
- retries failed sources while skipping completed sources
- validates safe unique source IDs
- escapes untrusted Markdown table content
- removes configurable remote hosts to prevent accidental media exfiltration
- avoids the API's capped rejection summary by using the complete local selection report

## Verification

GitHub Actions passed on the final head:

```text
cargo fmt --all --check
cargo clippy --all-targets -- -D warnings
cargo test
bash -n evals/run.sh
python3 -m py_compile evals/report.py
python3 -m unittest discover -s evals/tests -v

Ran 5 eval fixture tests — OK
```

## Remaining manual evidence before merge

- run the private six-slot real-media manifest locally
- review and score generated clips
- establish the first accepted baseline
- attach the generated delta report

No media, model, transcript, absolute source path, or generated clip is committed.

Refs #3
