### PR TITLE
Polish cancellation, clips, and studio UX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [dependencies]
 axum = { version = "0.8", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["rt"] }
+tokio-util = { version = "0.7", features = ["io", "rt"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Local-first podcast clipping with transcript ranking, face-aware reframing, and
 word-accurate captions. Built entirely in Rust.
 
 ![Rust](https://img.shields.io/badge/Rust-000000?logo=rust&logoColor=white)
-![CI](https://github.com/bramhacharyabishesha-hub/clipping-factory/actions/workflows/ci.yml/badge.svg)
+![CI](https://github.com/codingwithb/clipping-factory/actions/workflows/ci.yml/badge.svg)
 ![Local first](https://img.shields.io/badge/processing-local--first-1f6feb)
 ![Output](https://img.shields.io/badge/output-1080%C3%971920-7c3aed)
-![Tests](https://img.shields.io/badge/tests-62%20passing-238636)
+![Tests](https://img.shields.io/badge/tests-95%20passing-238636)
 
 </div>
 
@@ -200,7 +200,7 @@ Everything's overridable via environment variables: `CF_PORT`, `CF_DATA_DIR`, `C
 ### Tests
 
 ```bash
-cargo test   # 62 tests: every validator rule, caption pagination, crop math,
+cargo test   # 95 tests: every validator rule, caption pagination, crop math,
              # face-track smoothing & pan clamping, layout decisions, restyle
              # plumbing, selector parsing, state recovery
 ```

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ static/          the studio UI (served by the binary; embedded fallback)
 
 Everything's overridable via environment variables: `CF_PORT`, `CF_DATA_DIR`, `CF_OUTPUT_DIR`,
 `CF_FFMPEG`, `CF_FFPROBE`, `CF_WHISPER_BIN`, `CF_WHISPER_MODEL`, `CF_FONTS_DIR`,
-`CF_FACE_MODEL`, `CF_THREADS`, `CF_BIND_ALL=1`, `CF_NO_OPEN=1`.
+`CF_FACE_MODEL`, `CF_THREADS`, `CF_NO_OPEN=1`.
 
 ### Tests
 

--- a/TODOS.md
+++ b/TODOS.md
@@ -10,3 +10,4 @@ These items were deliberately kept out of `codex/product-polish` so the reliabil
 - Speaker-aware two-person framing.
 - Optional hosted selection relay, social publishing, analytics, teams, and payments.
 - Public/versioned HTTP API; `/api/*` remains an internal studio surface for this release.
+- Periodic free-space checks during very long uploads; this release reserves 1 GiB based on free space at upload start.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,12 @@
+# Deferred product work
+
+These items were deliberately kept out of `codex/product-polish` so the reliability release can finish with evidence.
+
+- Recent-project inbox/history with explicit cleanup and resume.
+- Tauri/macOS packaging after the source workflow is stable.
+- Transcript-word correction and start/end nudging, while preserving continuous source provenance.
+- SRT, transcript JSON, and edit-decision manifest export.
+- Project-wide caption templates or batch apply; this release remains per clip.
+- Speaker-aware two-person framing.
+- Optional hosted selection relay, social publishing, analytics, teams, and payments.
+- Public/versioned HTTP API; `/api/*` remains an internal studio surface for this release.

--- a/docs/PRODUCT_POLISH_PLAN.md
+++ b/docs/PRODUCT_POLISH_PLAN.md
@@ -1,0 +1,587 @@
+<!-- /autoplan restore point: /Users/bishesha/.gstack/projects/codingwithb-clipping-factory/codex-product-polish-autoplan-restore-20260810-110520.md -->
+# Clipping Factory Product Polish Plan
+
+Status: rough plan for GStack review
+Branch: `codex/product-polish`
+Base: `main`
+
+## Outcome
+
+Make the existing local-first Clipping Factory feel dependable and finished without adding accounts, cloud hosting, or a general-purpose editor. A user should be able to drop in one owned podcast video, understand what the app is doing, cancel work promptly at any stage, review each generated clip, adjust readable caption presentation, and recover cleanly from errors.
+
+## Premises
+
+1. This remains a single-user app running on the owner's device. Authentication and account flows are out of scope.
+2. Faithful clips remain contiguous excerpts. Caption controls change presentation, never spoken words or ordering.
+3. The existing Rust backend and plain HTML/CSS/JavaScript frontend are the product architecture. A framework rewrite is not required to finish the product.
+4. Existing cancellation code is unproven until upload, transcription, selection, framing, rendering, persistence, and UI behavior are tested.
+5. Editorial quality must be measured with the existing eval rubric and representative transcripts. We will not claim the algorithm is better from code inspection alone.
+6. Product polish means clear hierarchy, readable controls, keyboard/accessibility basics, truthful progress, actionable errors, and consistent recovery states.
+
+## Success Criteria
+
+- `main` remains untouched; all work stays on `codex/product-polish`.
+- The app builds and its existing test suite passes before and after changes.
+- Upload cancellation stops transfer and removes or marks partial project state safely.
+- Processing cancellation becomes visible within a bounded interval and terminates active FFmpeg/Whisper/provider work without starting later stages.
+- Refreshing after cancellation shows a truthful cancelled state; retry resumes only safe work.
+- Cancellation is idempotent and covered at API, pipeline, and subprocess boundaries.
+- Caption controls are easy to discover and support style, font, accent color, and the smallest useful set of readable layout/size choices supported by the renderer.
+- Color choices expose readable names/selection state and preserve sufficient contrast.
+- Clip cards make preview, source timestamps, rationale, status, restyle, retry, and download clear without crowding the primary actions.
+- Empty, uploading, processing, partially complete, cancelled, failed, zero-result, and complete states all have explicit UI behavior.
+- The selector/eval harness records baseline and post-change results on representative fixtures; any scoring change is justified by measured precision/quality, not output volume.
+- The local studio launches from this branch and is handed to the user at a stable localhost URL with exact test instructions.
+
+## Implementation Slices
+
+### Slice 1: Establish the baseline
+
+- Run `cargo test`, compile the release build, inspect current routes/state transitions, and run the existing eval harness.
+- Trace one project from upload through persisted state, including all cancellation token and child-process ownership paths.
+- Inventory current UX states and accessibility gaps from the actual running studio.
+
+Verify: baseline test/eval report, architecture map, and reproducible cancellation matrix.
+
+### Slice 2: Cancellation as a product invariant
+
+- Add focused tests that reproduce any cancellation leaks or stale state.
+- Make upload abort, pipeline cancellation, child-process termination, state persistence, SSE updates, and retry semantics consistent.
+- Disable duplicate actions while cancellation is pending and explain what completed artifacts are retained.
+
+Verify: automated cancellation tests plus live cancellation during at least transcription and rendering with no surviving child process or later-stage transition.
+
+### Slice 3: Finished studio interaction
+
+- Simplify information hierarchy and action labels across upload, processing, and results.
+- Make progress, elapsed time, cancel state, failures, partial results, and recovery actions truthful.
+- Improve focus states, keyboard operation, contrast, touch targets, responsive behavior, and reduced-motion behavior.
+
+Verify: GStack design review, browser QA at desktop and narrow widths, keyboard pass, and contrast check.
+
+### Slice 4: Caption controls and clip review
+
+- Keep the current post-render restyle architecture and expose a coherent caption control group.
+- Support the existing style, font, and accent options; add only renderer-backed size/layout choices that preserve safe areas and legibility.
+- Make each clip's current settings, apply progress, playback refresh, and error state obvious.
+
+Verify: unit tests for validation/plumbing, one live restyle per supported option, preview refresh, and output-file verification.
+
+### Slice 5: Editorial quality and performance
+
+- Audit local heuristic scoring, candidate diversity, overlap rejection, opening/closing boundaries, and provider fallbacks.
+- Expand representative eval fixtures before changing weights or rules.
+- Measure transcription/render cancellation latency, memory-heavy paths, and long-source behavior where practical.
+
+Verify: before/after eval comparison with no regression in faithfulness or diversity, plus benchmark notes for affected hot paths.
+
+### Slice 6: Release readiness
+
+- Run the full Rust tests, evals, formatter/lints, release build, live browser QA, code review, and performance checks.
+- Reconcile README screenshots/claims/test counts with verified behavior.
+- Launch the branch build locally for user testing. Do not merge to `main`.
+
+Verify: clean branch diff, evidence report, running local URL, and remaining risks listed explicitly.
+
+## Not in Scope
+
+- Login, accounts, teams, payments, hosted storage, or cloud video upload.
+- Automatic social posting.
+- Rewriting speech, jump-cut editing, timeline editing, B-roll, generated visuals, or music.
+- A frontend framework migration unless a concrete blocker is found and separately approved.
+- Claiming every possible bug is eliminated; the release bar is no known high-severity bug in tested workflows and explicit documentation of residual risk.
+
+## Initial Risk Register
+
+| Risk | User impact | Required evidence |
+|---|---|---|
+| Cancellation token does not own every spawned process | Mac keeps working after Cancel | Process and state checks during each stage |
+| Upload cancel differs from processing cancel | User cannot stop a mistaken large file | XHR abort and partial-file cleanup test |
+| Retry races a still-running task | Duplicate renders or corrupted state | Idempotency and concurrency tests |
+| More caption controls create unreadable combinations | Finished clips look worse | Constrained presets, validation, visual QA |
+| Selector changes increase quantity but reduce quality | More bad clips | Fixture-based before/after evals |
+| UI polish hides technical truth | User cannot tell whether work stopped or failed | State-by-state copy and live QA |
+
+## GStack Phase 1 — CEO Review
+
+Status: `AWAITING PREMISE CONFIRMATION`. Phase 2 design review has not started.
+
+### Premise gate
+
+The implementation plan proceeds only if these product premises are correct:
+
+1. The primary user is the owner/operator processing podcast footage on the same Mac; no login, hosted upload, team, or cloud workspace is needed.
+2. The release outcome is a faithful, publishable clip that can be reviewed and downloaded without another tool; reliability and editorial quality outrank the number of features.
+3. “Text options” means caption presentation (style, font, size/layout, highlight color, and readability), not rewriting spoken words or building a timeline editor.
+4. A clip remains one auditable, continuous source interval. The app never invents, reorders, or splices speech.
+5. The existing Rust/Axum and plain HTML/CSS/JavaScript implementation remains the delivery vehicle; there is no framework rewrite unless a proven blocker appears.
+6. Reliability is a release gate: later caption and ranking work does not begin until Cancel, retry, crash recovery, and artifact safety are proven.
+
+### Mode and 10x framing
+
+Mode: **Selective expansion**. The product should not compete with cloud editors feature for feature. Its sharper promise is a **private, faithful, auditable local clip compiler**:
+
+```mermaid
+flowchart LR
+  A["Current: local clipping pipeline with partial cancellation"] -->
+  B["This release: stop-safe, crash-safe, truthful, publishable clips"] -->
+  C["12-month ideal: durable local media appliance with project history and bounded resources"]
+```
+
+The 10x differentiators to make measurable are: video never uploads, every output maps to exact source timestamps, speech is never invented, cancellation becomes quiescent within a bounded time, and retries never trust partial artifacts.
+
+### What already exists
+
+| Sub-problem | Existing leverage | Decision |
+|---|---|---|
+| Project orchestration | `src/pipeline.rs`, `src/state.rs`, `CancellationToken` | Harden ownership and serialization; do not replace the pipeline wholesale. |
+| Subprocess cancellation | `src/util.rs::run_streaming` with kill-on-drop | Reuse for FFmpeg/Whisper; extend the invariant to probe/provider/CPU work. |
+| Durable project state | `src/store.rs`, project/transcript/candidate/manifest JSON | Add safe artifact lifecycle and project-scoped write serialization. |
+| Upload/progress | Axum multipart in `src/api.rs`, XHR in `static/app.js`, SSE | Add abort/cleanup and truthful preparing/cancelling states. |
+| Clip selection | `src/select/`, deterministic `src/validate.rs` | Fix reproduced correctness bugs, then tune only against fixtures. |
+| Caption restyle | Two-pass bases, `POST .../restyle`, `src/captions.rs` | Extend the renderer-backed model; no frontend-only fake controls. |
+| Clip review | Native previews, rank/reason/timestamps, download/open-folder | Improve state truth, hierarchy, accessibility, and partial-result copy. |
+| Evaluation | `evals/run.sh`, rubric scaffold | Turn the scaffold into a real baseline before claiming quality gains. |
+
+### Implementation alternatives
+
+| Approach | Effort | Risk | Advantages | Disadvantages | Decision |
+|---|---:|---:|---|---|---|
+| A. UI-only patch | Low | High | Fast visible change | Leaves runaway work, partial artifacts, and bad ranking unaddressed | Reject |
+| B. Reliability-gated hardening of existing architecture | Medium | Medium | Preserves working code, directly fixes trust, supports incremental proof | Requires careful concurrency and integration tests | **Select** |
+| C. New durable job supervisor/desktop rewrite | High | High | Strong long-term appliance model | Large migration and long-lived branch before user value | Defer; borrow only a minimal per-project supervisor concept if tests demand it |
+
+### Scope decisions
+
+Accepted now:
+
+- End-to-end cancellation, safe artifacts, serialized start/cancel/retry, truthful recovery UI.
+- Reproduced correctness fixes: Unicode-safe headlines, correct closing-quote occurrence, documented model precedence.
+- Real transcript fixtures and a measurable selector baseline before ranking changes.
+- Accessible caption presentation and clip review using renderer-backed controls.
+- Honest settings verification, errors, partial-result counts, and README/CI claims.
+
+Deferred:
+
+- General timeline editing, B-roll, transitions, generated speech, social posting, analytics, teams, and cloud relay.
+- Full recent-project library and Tauri packaging; keep filesystem state compatible with them.
+- Transcript word correction and interval nudging unless the premise gate says “text options” includes editing content.
+- Import/export integrations beyond finished MP4; consider SRT/transcript/edit-decision export after the core loop is proven.
+
+### Temporal interrogation
+
+| Time | Expected evidence | Stop condition |
+|---|---|---|
+| Hour 1 | Tests reproduce Unicode, quote matching, model precedence, cancellation state bugs | No implementation without a failing test for each bug |
+| Hours 2–6 | Upload abort/cleanup, subprocess/provider cancellation, temp-file writes, serialized actions | Stop if Cancel can acknowledge before work is quiescent |
+| Day 2 | Truthful UI state matrix and keyboard/narrow-screen QA | Stop if UI can hide a running project |
+| Day 3 | Golden transcript fixtures, baseline, conservative editorial gates | Stop if quality cannot be measured |
+| Day 4+ | Caption/readability polish, full review, release build, live media QA | Do not claim finished without real-media evidence |
+
+### CEO dual voices
+
+**Independent subagent:** `DONE_WITH_CONCERNS`. It found an undefined success outcome, six releases hidden in one branch, a missing local/private/faithful product wedge, and a risk that a reliable app still produces clips needing another editor. It recommended hard reliability gates and a publishable-result metric.
+
+**Codex CEO voice:** unavailable after successful auth/version preflight because the local Codex runner binary `/Users/bishesha/.local/bin/codex-code-mode-host` is missing. The phase continues in `[subagent-only]` mode as required by GStack.
+
+| Dimension | Subagent | Codex | Consensus |
+|---|---|---|---|
+| Premises valid | Concerns | N/A | Flagged for premise gate |
+| Right problem | Reliability yes; publishability underspecified | N/A | Flagged |
+| Scope calibration | Too broad without release gates | N/A | Reliability gate adopted |
+| Alternatives explored | Interoperability missing | N/A | Export path deferred explicitly |
+| Competitive risk | Commodity feature race | N/A | Local/private/faithful wedge adopted |
+| Six-month trajectory | Risk of dependable intermediate tool | N/A | Publishable outcome added |
+
+### Review Sections 1–11
+
+#### 1. Architecture
+
+The main architectural defect is lifecycle ownership, not technology choice. `running`, the cancellation token, persisted state, output files, and UI actions can disagree. Introduce one serialized project-operation boundary and write reusable artifacts through unique temporary files plus atomic promotion. Keep the current stage modules.
+
+#### 2. Error and rescue
+
+Errors are often stringly typed and UI actions ignore non-2xx responses. Return structured recovery information where needed, preserve the last known-good settings, and expose explicit Retry, Choose another MP4, and Cancel-and-start-over actions.
+
+#### 3. Security and privacy
+
+Local bind/default privacy and transcript-only provider calls are good foundations. Verify provider cancellation and timeouts, never log secrets, test candidate settings before persisting them, and keep video bytes off provider paths. Authentication remains correctly out of scope.
+
+#### 4. Data flow and interaction edges
+
+Audit every transition across empty, uploading, preparing, processing, cancelling, cancelled, failed, partial, zero-result, and complete. A new project must not detach from live work. Refresh/restart must derive truth from persisted state plus the actual running handle.
+
+#### 5. Code quality
+
+Use the minimum new abstraction: a project-scoped operation guard and artifact helper only if the tests show repeated need. Fix the UTF-8 byte-slice panic and repeated-quote lookup directly. Do not refactor unrelated modules.
+
+#### 6. Tests
+
+Baseline is 72/72 passing, but there are no cancellation, API, provider, pipeline-concurrency, actual recovery, or quality-fixture tests. Add focused regression tests first. The README count of 62 is stale.
+
+#### 7. Performance
+
+Cancellation latency is the first performance metric. Provider selection can make up to 24 sequential calls for a four-hour source; full non-range clip responses buffer the complete file. Measure before parallelizing and stream large responses where safe.
+
+#### 8. Observability and debugging
+
+SSE and persisted stage details exist, but cancellation acknowledgements do not mean stopped. Record operation identity/state transitions and make errors actionable. The eval report must include commit, settings, source fingerprint, timeout, and delta.
+
+#### 9. Deployment and rollout
+
+Work stays on `codex/product-polish`; no merge to `main`. Release proof requires format, clippy, tests, eval, release build, browser QA, real-media cancellation, and no surviving child process. The documented CI workflow is not active in `.github/workflows` and must not be claimed as active.
+
+#### 10. Long-term trajectory
+
+Preserve compatibility with a future durable project inbox and desktop shell without building them now. Avoid the incumbent feature race. The moat is local privacy, provenance, reliability, and conservative editorial quality.
+
+#### 11. Design and UX
+
+The studio is visually quiet but too small and semantically weak: 14px body text, 11–13px controls, undersized color targets, no robust dialog focus, limited live-region semantics, and partial results presented as complete. Raise legibility, make action hierarchy state-dependent, and keep caption choices named, constrained, and previewable.
+
+### Error & Rescue Registry
+
+| Failure | Current rescue gap | Required rescue | Verification |
+|---|---|---|---|
+| Upload aborted | No cancel; orphan directory possible | Abort active XHR; server cleanup; return to import | Throttled abort at 25% and post-upload preparation |
+| Cancel during probe/provider/face detect | Work can continue | Token/timeout reaches operation; no later stage starts | Gated fake operations with bounded stop |
+| Cancel during FFmpeg output | Partial WAV/base may be reused | Temp output, cleanup, atomic promotion | Write-then-block fake child; retry rebuilds |
+| Cancelled UI | Stage remains active; elapsed continues | Terminal cancelled metadata and visible recovery actions | Refresh state snapshot and timer assertion |
+| Duplicate Retry/Cancel | Racy mutation/start | Serialized idempotent operation; disabled pending control | Barrier-concurrent API test |
+| Failed AI test | Bad settings already saved | Test candidate first; retain last known-good | Invalid key/model test |
+| Early failure, zero clips | User trapped on Retry | Choose another MP4 | State-matrix browser test |
+| Partial render | Headline implies full success | Ready/failed counts and targeted retry | Mixed-manifest UI test |
+| Eval run fails | Harness may treat it as completion | Timeout and terminal status validation | Failed/timed-out fixture run |
+
+### Failure Modes Registry
+
+| Mode | Severity | Prevention/detection |
+|---|---|---|
+| Cancel signals old token while new run proceeds | P0 | Install/own token atomically under project operation guard |
+| Fixed JSON temp path collides across writers | P0 | Project write serialization or unique temp files |
+| Truncated WAV/base passes existence check | P0 | Atomic promotion and artifact validity contract |
+| Generic filler passes local quality gate | P0 | Golden transcript baseline plus hook/specificity/housekeeping fixtures |
+| Unicode headline panics | P1 | Character-boundary truncation test |
+| Repeated closing phrase falsely rejects | P1 | Last/all-occurrence validation test |
+| New Project hides live render | P0 | Cancel-and-wait or disallow reset while running |
+| Restyle rerender loses another clip's busy state | P1 | Persistent per-clip UI operation state |
+| Full clip response spikes memory | P1 | Streaming response test and implementation |
+
+### Dream-state delta
+
+This release should end with a trustworthy single-project local studio, not the full local media appliance. Remaining 12-month deltas are recent-project history, resource scheduling, close-browser job supervision, packaging, richer correction/export, and broader real-media golden sets.
+
+### Implementation tasks
+
+| ID | Priority | Task | Proof |
+|---|---|---|---|
+| T1 | P0 | Serialize project operations and make cancellation acknowledgement mean quiescent | Concurrency/cancellation integration tests |
+| T2 | P0 | Abort/clean interrupted upload and distinguish upload from preparation | Throttled multipart tests |
+| T3 | P0 | Make WAV/base/final artifacts atomic and retry-safe | Partial-child regression tests |
+| T4 | P0 | Build truthful state/recovery UI and safe New Project behavior | Full state matrix + browser QA |
+| T5 | P1 | Fix Unicode, quote occurrence, model precedence, settings verification | Focused unit/API tests |
+| T6 | P0 | Establish quality fixtures/baseline, then tighten local selector | Before/after scored report |
+| T7 | P1 | Finish accessible clip/caption controls using renderer-backed options | Keyboard, contrast, restyle output checks |
+| T8 | P1 | Stream large clip responses and bound provider work | Benchmark and request tests |
+| T9 | P0 | Full release verification and live branch launch | Test/eval/build/browser/process evidence |
+
+### Phase 1 completion summary
+
+| Area | Result |
+|---|---|
+| Strategy | Reliability-first local/private/faithful wedge |
+| Baseline | 72 tests pass; no real eval baseline |
+| Critical product gaps | Cancellation lifecycle, artifact safety, UI truth, generic-filler selection |
+| Selected approach | Harden existing architecture behind release gates |
+| Outside voices | Subagent completed; Codex degraded due missing local runner host |
+| Unresolved decision | Whether “text options” includes transcript-word editing |
+| Gate | User premise confirmation required before GStack design/engineering/DX reviews |
+
+## GStack Phase 2 — Design Review
+
+Status: complete. Initial design-spec completeness was **4/10**; the decisions below raise it to **8/10**. A 10/10 still requires live browser validation with real processing/results data. No `DESIGN.md` exists. GStack visual variants were attempted but its designer has no configured API key, so this review used the existing studio, wireframe, screenshots, and universal app-UI principles.
+
+### Screen hierarchy
+
+```text
+Persistent header: Clipping Factory identity | local/verified selector status
+└── Project workspace
+    ├── Empty: Drop/Choose MP4 → summarized output preset → privacy/setup detail
+    ├── Active: Current operation + Stop → progress/counts → source/stage history
+    ├── Partial: Ready/Rendering/Failed summary → playable ready clips → recovery
+    ├── Complete: Outcome + best clip → clip review/restyle → folder/new project
+    └── Failed/Stopped: What happened → what was preserved → one recovery + one exit
+```
+
+Constraint: one primary action and one secondary escape per state. Import is the dominant empty-state action; framing/accent stay summarized and editable, while provider settings remain secondary because local ranking is usable by default.
+
+### Visible-state contract
+
+| State | What the user sees | Primary | Secondary | Announcement / transition |
+|---|---|---|---|---|
+| Restoring | “Restoring your last project…”; import hidden | None | None | Polite status; resolve to persisted state or empty |
+| Empty | Drop target, Choose MP4, current output summary | Choose MP4 | Adjust output | Focus begins at import; privacy copy is tertiary |
+| Uploading | Filename, byte progress, Uploading | Cancel upload | None | Progressbar semantics; abort returns to Empty |
+| Preparing | “Upload complete. Preparing project…” | Stop | None | Do not leave the label as Uploading |
+| Processing | Plain-language current operation, elapsed time, stage progress | Stop | None | Stop becomes “Stopping…” and disables immediately |
+| Reconnecting | Last known state plus “Reconnecting live updates…” | None | Retry connection | Never silently appear frozen |
+| Partial | “X ready, Y rendering, Z failed”; ready previews first | Review ready clips | Retry failed clips | Never use complete-result wording |
+| Stopped | “Stopped. X finished clips were kept.” | Resume safely | Choose another MP4 | Shown only after work is quiescent |
+| Failed | What failed, why, preserved artifacts | Retry when safe | Choose another MP4 | Error receives focus; no retry-only trap |
+| Zero result | Quality bar protected the user; rejection summary | Choose another MP4 | Review rejections | Avoid blame or “nothing found” dead end |
+| Complete | Outcome count, best clip, saved location | Review/download | Open folder / New project | Success status; preview must play |
+
+New Project during live work means **Cancel and start over**: request stop, wait for quiescence, then reset. Results may appear as soon as a clip is ready, but only under the Partial heading.
+
+### Caption control contract
+
+Per-clip only for this release. State machine: `idle → changed → applying → applied` or `error`. Apply is disabled when unchanged, reads **Apply captions**, persists busy state across rerenders, and announces success only after the refreshed preview can load. Ship existing renderer-backed style/font/color choices; defer new size/layout presets until the renderer contract is implemented and tested.
+
+### User journey and emotional arc
+
+| Step | User does | Intended feeling | Design support |
+|---|---|---|---|
+| Import | Drops one owned podcast | Confidence | One dominant action; local/privacy promise |
+| Configure | Reviews a small preset summary | Agency without homework | Progressive disclosure and safe defaults |
+| Wait | Watches a long local job | Patience and orientation | Current operation, elapsed time, truthful progress |
+| Stop | Cancels mistaken/unwanted work | Control | Immediate Stopping state; terminal proof of what was kept |
+| Review | Plays ranked clips | Informed judgment | Preview, exact timestamps, rationale, partial truth |
+| Restyle | Changes caption presentation | Creative control | Named constrained choices and fast feedback |
+| Finish | Downloads or opens the folder | Satisfaction | Playable output and visible save location |
+
+Time horizons: in five seconds the current state/action is obvious; in five minutes long work remains understandable and stoppable; over repeated use the app earns trust through conservative quality and exact provenance.
+
+### Seven-pass scorecard
+
+| Pass | Before | After | Auto-decision |
+|---|---:|---:|---|
+| Information architecture | 4 | 9 | Lock state-specific first/second/third hierarchy |
+| Interaction coverage | 5 | 9 | Adopt the visible-state contract above |
+| Journey/emotional arc | 3 | 8 | Add trust/control storyboard; validate copy live |
+| AI-slop risk | 8 | 9 | Keep quiet task-focused layout; reject card grids, gradients, decorative icons, and generic SaaS copy |
+| Design-system alignment | 4 | 7 | Use existing paper/ink tokens; add explicit type/spacing/focus rules without a rebrand |
+| Responsive/accessibility | 5 | 9 | Mac desktop first plus intentional 320/375/768 widths and short-height behavior |
+| Unresolved decisions | 4 | 8 | Resolve state actions and per-clip scope; renderer size/layout remains explicitly deferred |
+
+### Visual baseline
+
+- App UI, not a landing page: quiet surfaces, minimal chrome, one restrained amber accent, semantic success/error colors.
+- Body and controls are at least 16px; secondary metadata may be smaller only when nonessential and AA compliant.
+- 4px/8px spacing rhythm; modest borders/radii; no decorative shadows or gradients.
+- Every interactive target is at least 44px; `:focus-visible` is unmistakable.
+- Long filenames wrap; modal content scrolls in short viewports; clip rows become a deliberate single column on narrow screens.
+- Motion is limited to useful progress feedback and obeys `prefers-reduced-motion`.
+
+### Design dual voice
+
+Independent product-design subagent: 12 findings, including unspecified screen hierarchy, missing degraded states, cancellation not designed as a trust moment, and a slice order that separated backend truth from visible proof. Codex design voice remained unavailable because the local code-mode host is missing. Degradation: `[subagent-only]`.
+
+| Litmus dimension | Subagent | Codex | Result |
+|---|---|---|---|
+| Product/state unmistakable | Concern before hierarchy | N/A | Resolved in plan |
+| One visual anchor | Current operation recommended | N/A | Adopted |
+| Scannable hierarchy | Critical gap | N/A | Adopted |
+| One job per section | Empty screen too choice-heavy | N/A | Progressive disclosure adopted |
+| Cards necessary | Clip card is the interaction | N/A | Keep; reject decorative cards |
+| Motion purposeful | Reduced to progress/status | N/A | Adopted |
+| Premium without decoration | Yes with typography/spacing fixes | N/A | Adopted |
+
+**Phase 2 complete.** Subagent: 12 issues. Codex: unavailable. No model disagreement; structural issues were auto-decided. Passing to Phase 3.
+
+## GStack Phase 3 — Engineering Review
+
+Status: complete. Review was performed against the actual code and the in-progress Luna reliability diff. The current compile errors are expected red-phase findings and must be green before integration.
+
+### Scope challenge and chosen architecture
+
+Do not add a second job system. Deepen the existing `AppState`/`ProjectHandle` boundary so one generation owns its token, completion signal, persistence mutations, and artifact lifecycle.
+
+```text
+Browser (XHR + fetch + SSE)
+        │
+        ▼
+Axum API ── input/body/bind policy
+        │
+        ▼
+AppState
+  ├── global admission semaphore (bounded heavy jobs)
+  └── ProjectHandle
+       ├── operation mutex / generation
+       ├── CancellationToken + bounded completion
+       ├── project mutation serialization
+       └── event broadcast
+                │
+                ▼
+Pipeline stages
+  probe → extract → transcribe → select → validate → frame → render
+                │                           │
+                ├── cancellable processes/HTTP/CPU work
+                └── temp artifact → validate → atomic promote
+                │
+                ▼
+Store (project/transcript/candidates/manifest) + output directory
+```
+
+The API/UI contract must distinguish **signal accepted**, **stopping**, and **quiescent stopped**. Panics and timeouts must still release the generation through an RAII/finalizer path.
+
+### Independent engineering voice
+
+The subagent reported eight issues: current in-progress async caller compile breaks, unbounded cancel waits, project-write serialization gaps, unsafe/unbounded upload, missing 10x admission control, full-file response buffering, `CF_BIND_ALL` exposure without auth, and missing injectable/router/browser test seams. Codex engineering voice is unavailable because the local code-mode host is missing. Degradation: `[subagent-only]`.
+
+| Dimension | Subagent | Codex | Result |
+|---|---|---|---|
+| Architecture sound | Existing modules sound; lifecycle boundary incomplete | N/A | Harden existing boundary |
+| Test coverage sufficient | No | N/A | Test diagram adopted |
+| Performance risks addressed | No: concurrency and buffering | N/A | Admission/streaming tasks added |
+| Security threats covered | No: bind-all unauthenticated | N/A | Disable bind-all for release or token-gate |
+| Error paths handled | No: panic/hang/upload cleanup | N/A | Finalizer/deadline/cleanup required |
+| Deployment risk manageable | Yes only behind release gates | N/A | No merge until green/live proof |
+
+### Code-quality decisions
+
+- One explicit project-operation mechanism is preferable to independent booleans/locks for start, cancel, retry, recovery, and restyle writes.
+- Unique temp outputs plus atomic promotion replace existence-as-validity; do not add format-specific validation in every caller.
+- Keep errors structured at API boundaries but avoid a repository-wide error rewrite.
+- Preserve current module names and plain frontend. Remove only dead code introduced by these changes.
+
+### Test diagram
+
+| New flow/codepath | Branches to prove | Test type | Required |
+|---|---|---|---|
+| Upload lifecycle | success, abort, oversize, empty, corrupt, disk error | Axum multipart integration | P1 |
+| Start/cancel ownership | cancel-before-start, during-start, duplicate cancel, panic, timeout | Tokio concurrency/integration | P1 |
+| Retry lifecycle | running conflict, double retry, cancelled retry, interrupted restart | Tokio + persisted-state integration | P1 |
+| Artifact promotion | child fails/cancels after writing, rename fails, valid reuse | Fake process/filesystem integration | P1 |
+| Probe/transcribe/select/frame/render | cancel before/during/after each, no next stage | Injectable stage/process tests | P1 |
+| Provider selection | timeout, token cancel, late-window failure, no later billed request | Mock HTTP server | P1 |
+| Store/restyle writes | parallel restyles, retry+restyle, recovery+save | Barrier concurrency | P1 |
+| Job admission | ten starts, queued cancel, bounded child count | Semaphore integration | P2 |
+| Clip serving | full, bounded range, suffix/open range, invalid 416, parallel clients | Router/stream tests | P2 |
+| Studio state matrix | restore, upload, prepare, process, reconnect, partial, stop, fail, zero, complete | Browser DOM/network tests | P1 |
+| Caption controls | dirty, no-op, applying, success, error, concurrent clips | Browser/unit seam | P2 |
+| Local selector | filler, sponsor, insight, Unicode, repeated quote, containment overlap | Rust fixture tests | P1 |
+| Eval harness | timeout, failed terminal, provenance, baseline/delta | Shell fixture tests | P1 |
+| Network boundary | loopback default, bind-all rejection/token, origin | Startup/router tests | P1 |
+
+### Performance and security decisions
+
+- Add a small configurable semaphore for heavy pipelines now; a queueing product UI may be deferred, but direct API calls must not spawn unbounded FFmpeg/Whisper work.
+- Stream full/range clip responses in bounded chunks; malformed or unsatisfiable ranges return `416` rather than silently serving the full clip.
+- The release remains loopback-only. `CF_BIND_ALL` is disabled/removed unless every API/SSE route gains a generated token and origin restriction; authentication remains unnecessary on loopback.
+- Uploads get a route-specific maximum, disk-space preflight, temporary destination, cleanup guard, and media validation before promotion.
+
+### Failure-mode critical gaps
+
+| Gap | Severity | Ship gate |
+|---|---|---|
+| Async start/cancel callers or missing Store helper leave branch uncompilable | P0 | `cargo check`/clippy/test green |
+| Cancel waits forever after panic or uncancellable stage | P0 | Deadline/finalizer/cancel tests |
+| Concurrent pipeline/restyle/recovery writes lose state | P0 | Project mutation + barrier tests |
+| Aborted/oversize upload exhausts disk or leaves project | P0 | Upload integration tests |
+| Direct API calls spawn unbounded heavy work | P1 | Admission-limit test |
+| Full clip downloads multiply RAM per client | P1 | Streaming/range tests |
+| Bind-all exposes private local operations | P1 | Loopback-only startup proof |
+
+### Engineering completion summary
+
+| Area | Decision |
+|---|---|
+| Component structure | Keep existing modules; deepen ProjectHandle ownership |
+| Hidden complexity | Cancellation is a distributed lifecycle, not a button/token |
+| 10x load | Bound heavy jobs and response memory |
+| Security | Loopback only; body/disk bounds; no auth flow |
+| Testing | Add seams only where needed to prove stage/process/router behavior |
+| Rollout | Reliability vertical slice → correctness/eval → UI/captions → live release proof |
+
+**Phase 3 complete.** Subagent: eight issues. Codex: unavailable. Passing to Phase 3.5.
+
+## GStack Phase 3.5 — Developer Experience Review
+
+Mode: **DX POLISH**. Primary persona: a Mac creator/operator comfortable pasting terminal commands but not debugging Rust/media toolchains. Initial DX completeness: **5/10**.
+
+### Developer journey
+
+| Stage | Current experience | Target |
+|---|---|---|
+| 1. Discover | README explains local-first product | Keep promise concise and evidence-qualified |
+| 2. Prerequisites | Homebrew/Rust assumptions are implicit | Supported OS and prerequisites stated first |
+| 3. Obtain | Clone/`cd` missing from Quickstart | One copy-paste block from clone to launch |
+| 4. Install runtimes | Multiple package/tool steps | One bootstrap/doctor path with manual fallback |
+| 5. Install model | Separate 148 MB command | Doctor reports exact path and copy-paste fix |
+| 6. Launch | `cargo run --release`; long first build | Expected output and URL; repeat launch under five minutes |
+| 7. First success | Requires the user’s own MP4 | Tiny owned/synthetic smoke option plus clear empty state |
+| 8. Diagnose | Setup banner has partial checks | `doctor`-quality problem + cause + fix messages |
+| 9. Upgrade/rollback | Unspecified | Versioned state, backup, changelog, rollback/export guidance |
+
+### Developer empathy narrative
+
+“I want a local clipping tool, not a Rust project. I can paste commands, but I need to know prerequisites before a long build, see exactly which dependency or model is missing, and get one visible success without diagnosing FFmpeg flags. If an upgrade touches my projects, I need a backup and a way back. The HTTP API should either be clearly internal or documented consistently; half-documented endpoints make me afraid to depend on it.”
+
+### TTHW
+
+Cold clean-machine TTHW is likely **15–30+ minutes** because Homebrew packages, Rust, model download, compilation, and a user video are required. Warm repeat launch is under five minutes. This source release targets **under 10 minutes cold with an existing Rust toolchain and under five minutes warm**; a packaged desktop build is the later path to true under-five-minute cold start.
+
+### DX scorecard
+
+| Dimension | Score | Required improvement |
+|---|---:|---|
+| Getting started | 4/10 | Complete clone-to-launch blocks and prerequisites |
+| Time to first success | 3/10 | Doctor + small legal smoke source/path |
+| API/CLI ergonomics | 6/10 | Mark API internal or publish one consistent contract |
+| Error quality | 5/10 | Problem + cause + fix + retryability; stable codes where useful |
+| Documentation | 6/10 | Reconcile claims, config table, troubleshooting |
+| Defaults/escape hatches | 6/10 | Explain precedence; remove unsafe bind-all escape hatch |
+| Upgrade safety | 2/10 | Versioned state, backup, migration, rollback |
+| Dev environment | 6/10 | Doctor/checks; keep single Rust binary architecture |
+
+Overall: **4.8/10** now, target **8/10** for the source release.
+
+### DX decisions and checklist
+
+- [ ] Quickstart includes Homebrew prerequisite, clone, `cd`, Rust shell activation, model, launch, expected URL, and common failure checks.
+- [ ] Setup/doctor output names the problem, likely cause, exact command/path to fix, and whether restart is needed.
+- [ ] README claims reflect verified test count, active CI reality, and measured cancellation/recovery behavior.
+- [ ] `CF_*` configuration is a table with type/default/allowed value/precedence/example.
+- [ ] `/api/*` is explicitly internal/unstable for this release; remove isolated endpoint marketing unless a compact reference is added.
+- [ ] `CF_BIND_ALL` is removed/disabled for the unauthenticated local release.
+- [ ] Persisted state carries a schema/app version and is backed up before migration; rollback/export is documented before packaging.
+
+### DX dual voice
+
+The independent DX subagent reported eight issues: slow/ambiguous TTHW, incomplete clean-machine Quickstart, claims that contradict evidence, no error contract, unclear API support, opaque configuration, unsafe bind-all, and no upgrade/rollback story. Codex DX voice is unavailable because the local code-mode host is missing. Degradation: `[subagent-only]`.
+
+| Dimension | Subagent | Codex | Result |
+|---|---|---|---|
+| Getting started under 5 min | No | N/A | Source target calibrated; packaged path deferred |
+| Naming guessable | Mixed | N/A | Mark HTTP API internal |
+| Errors actionable | No | N/A | Message contract adopted |
+| Docs complete/findable | No | N/A | Quickstart/config/troubleshooting tasks adopted |
+| Upgrade safe | No | N/A | Version/backup requirement added |
+| Environment friction-free | No | N/A | Doctor/bootstrap direction adopted |
+
+**Phase 3.5 complete.** Overall DX: 4.8/10 → 8/10 target. Cold TTHW: 15–30+ minutes → under 10 source target; warm target under five. Subagent: eight issues. Codex: unavailable. Passing to integration and release verification under the user’s explicit implementation approval.
+
+## Cross-phase themes
+
+1. **Truth is the product.** CEO, design, engineering, and DX independently found that claims, visible states, persisted state, and actual work can disagree.
+2. **Reliability must be vertical.** Design and engineering both require backend quiescence, artifact safety, and user-visible stopping/recovery to land together.
+3. **Evidence before claims.** CEO/editorial, engineering, and DX found empty evals, stale test/CI claims, and missing live proof.
+4. **Avoid the feature race.** Strategy and design converge on a quiet local/private/faithful tool with constrained caption presentation, not a cloud editor clone.
+
+## Decision Audit Trail
+
+| # | Phase | Decision | Classification | Principle | Rationale | Rejected |
+|---|---|---|---|---|---|---|
+| 1 | CEO | Local/private/faithful compiler is the product wedge | Auto | Completeness | Defensible and matches explicit no-auth/local premise | Cloud feature race |
+| 2 | CEO | Reliability is a hard gate before ranking/caption polish | Auto | Simplicity | Prevents six unfinished releases in one branch | Parallel feature completion without proof |
+| 3 | CEO | Keep Rust/plain frontend | Auto | Leverage | Existing modules are sound enough; no blocker supports rewrite | Framework/desktop rewrite |
+| 4 | Design | One primary action plus one escape in every state | Auto | Simplicity | Removes competing controls and dead ends | Showing every available action |
+| 5 | Design | Partial clips appear early only under truthful counts | Auto | Completeness | Preserves useful output without implying completion | Hide all clips or claim full success |
+| 6 | Design | Caption editing is per-clip presentation only | User-confirmed | User premise | User approved implementation after premise gate | Transcript/timeline editing |
+| 7 | Design | Mac desktop first with intentional narrow widths | Auto | Completeness | Local product reality plus accessibility | Desktop-only overflow or arbitrary stacking |
+| 8 | Eng | Deepen ProjectHandle lifecycle instead of new job system | Auto | Simplicity | Smallest architecture that centralizes truth | Second orchestration framework |
+| 9 | Eng | Unique temp artifacts and atomic promotion | Auto | Safety | Existence cannot prove completeness | Reuse direct-to-final partial files |
+| 10 | Eng | Bound heavy jobs and stream clip responses | Auto | Completeness | Prevents 10x resource collapse | Unbounded direct API concurrency |
+| 11 | Eng | Loopback-only release | Auto | Safety | No auth is safe only at the local boundary | Unauthenticated bind-all |
+| 12 | DX | Mark HTTP API internal for this release | Auto | Simplicity | Avoids accidental compatibility promises | Partial public API documentation |
+| 13 | DX | Source TTHW target under 10 cold, under 5 warm | Taste | Practicality | Packaging is out of this slice | Pretending source install is under five |

--- a/evals/fixtures/editorial_cases.json
+++ b/evals/fixtures/editorial_cases.json
@@ -1,0 +1,74 @@
+[
+  {
+    "name": "generic-housekeeping",
+    "expected": "reject",
+    "sentences": [
+      "Welcome back to the show.",
+      "Today we are going to talk about the format and the schedule.",
+      "Before we begin remember to subscribe and leave a review.",
+      "We will be right back after a short break.",
+      "Thanks for listening and we hope you enjoy the episode.",
+      "Now let us get into the conversation for today."
+    ]
+  },
+  {
+    "name": "filler-dominated",
+    "expected": "reject",
+    "sentences": [
+      "Um, uh, like, you know, this is kind of sort of the point.",
+      "I mean, like, you know, we are um basically talking about stuff.",
+      "It is, uh, kind of hard to say, you know, what the answer is.",
+      "So, like, we just sort of keep going and, um, hope it works.",
+      "You know, I mean, the thing is, uh, we are still figuring it out.",
+      "Basically, like, that is sort of all I wanted to say today."
+    ]
+  },
+  {
+    "name": "sponsor-intro",
+    "expected": "reject",
+    "sentences": [
+      "This episode is brought to you by Acme Tools.",
+      "Acme makes simple tools for people who build useful things.",
+      "Use the code FACTORY for a discount at checkout.",
+      "We appreciate their support for the show and its listeners.",
+      "You can find the sponsor link in the episode notes.",
+      "Now let us get into the conversation for today."
+    ]
+  },
+  {
+    "name": "strong-standalone-insight",
+    "expected": "accept",
+    "sentences": [
+      "The biggest mistake is waiting to feel motivated before starting.",
+      "Motivation follows a visible first step, so make the first step tiny.",
+      "When the next action is obvious, your environment does the persuading.",
+      "That is why a small system beats a heroic burst of effort.",
+      "You can repeat the system even on a difficult day.",
+      "The result is progress that does not depend on perfect feelings."
+    ]
+  },
+  {
+    "name": "repeated-claim",
+    "expected": "accept",
+    "sentences": [
+      "Everyone can learn the skill if the practice is specific.",
+      "The point is to make the practice visible every morning.",
+      "A visible routine gives feedback before frustration takes over.",
+      "Everyone can learn the skill if the practice is specific.",
+      "That repeated idea matters because consistency beats intensity.",
+      "The lesson is to design practice that you can actually repeat."
+    ]
+  },
+  {
+    "name": "accented-unicode",
+    "expected": "accept",
+    "sentences": [
+      "The biggest lesson from the café is to measure one change at a time.",
+      "A résumé of small experiments is more useful than a grand theory.",
+      "Clear examples make a naïve assumption visible before it causes trouble.",
+      "That is why a small checklist beats a clever slogan.",
+      "The team can adjust the process without losing the original meaning.",
+      "Progress stays practical when every example remains easy to explain."
+    ]
+  }
+]

--- a/evals/fixtures/overlap_containment.json
+++ b/evals/fixtures/overlap_containment.json
@@ -1,0 +1,8 @@
+{
+  "name": "overlap-containment",
+  "word_count": 200,
+  "word_ms": 400,
+  "higher_ranked": { "start_ms": 10000, "end_ms": 30000 },
+  "lower_ranked": { "start_ms": 10000, "end_ms": 100000 },
+  "expected": "reject-lower-ranked-containing-clip"
+}

--- a/evals/rubric.csv
+++ b/evals/rubric.csv
@@ -1,1 +1,7 @@
-source,clip_rank,headline,hook_1to5,standalone_1to5,payoff_1to5,caption_accuracy_1to5,framing_1to5,would_post_1to5,notes
+source,clip_rank,headline,hook_1to5,standalone_1to5,payoff_1to5,caption_accuracy_1to5,framing_1to5,would_post_1to5,notes,expected_selector_outcome,observed_selector_outcome
+synthetic:generic-housekeeping,,,,,,,,,,reject,
+synthetic:filler-dominated,,,,,,,,,,reject,
+synthetic:sponsor-intro,,,,,,,,,,reject,
+synthetic:strong-standalone-insight,,,,,,,,,,accept,
+synthetic:repeated-claim,,,,,,,,,,accept,
+synthetic:accented-unicode,,,,,,,,,,accept,

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -1,48 +1,503 @@
 #!/usr/bin/env bash
 # Run every MP4 in evals/sources/ through a running Clipping Factory studio
-# and collect the resulting project views for scoring.
+# and collect project views, provenance, and a comparable summary.
 #
-# Usage:  bash evals/run.sh [host]        (default http://localhost:4571)
+# Usage:
+#   bash evals/run.sh [host]
+#   bash evals/run.sh --fixtures
+#
+# The fixture mode validates the copyright-free synthetic controls and, unless
+# CF_EVAL_RUN_CARGO=0, runs their focused Rust tests without requiring Studio.
 set -euo pipefail
 
-HOST="${1:-http://localhost:4571}"
+HOST="${CF_EVAL_HOST:-http://localhost:4571}"
 ROOT="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$ROOT/.." && pwd)"
 SOURCES="$ROOT/sources"
-RUN_DIR="$ROOT/results/$(date +%Y%m%d-%H%M%S)"
+RESULTS_ROOT="${CF_EVAL_RESULTS_DIR:-$ROOT/results}"
+TIMEOUT_SECONDS="${CF_EVAL_TIMEOUT_SECONDS:-7200}"
+POLL_SECONDS="${CF_EVAL_POLL_SECONDS:-5}"
+BASELINE="${CF_EVAL_BASELINE:-}"
+MODE="real_media"
+TEMP_TARGET_DIR=""
+readonly CURL_CONNECT_TIMEOUT_SECONDS=10
+readonly CURL_CANCEL_TIMEOUT_SECONDS=10
 
-command -v jq >/dev/null || { echo "jq is required (brew install jq)"; exit 1; }
-curl -sf "$HOST/api/setup" >/dev/null || { echo "Studio not reachable at $HOST — start it with: cargo run --release"; exit 1; }
+usage() {
+  cat <<'EOF'
+Usage: bash evals/run.sh [host] [--timeout SECONDS] [--baseline SUMMARY]
+       bash evals/run.sh --fixtures [--baseline SUMMARY]
+
+Environment overrides:
+  CF_EVAL_RESULTS_DIR       output root (default evals/results)
+  CF_EVAL_TIMEOUT_SECONDS   per-source wall-clock timeout (default 7200)
+  CF_EVAL_POLL_SECONDS      project poll interval (default 5)
+  CF_EVAL_BASELINE          previous summary.json to compare
+  CF_EVAL_RUN_CARGO=0       fixture mode: validate manifests without cargo
+  CF_EVAL_TARGET_DIR        fixture mode: external cargo target directory
+EOF
+}
+
+die() {
+  echo "evals/run.sh: $*" >&2
+  exit 1
+}
+
+cleanup_temp_target() {
+  if [[ -n "$TEMP_TARGET_DIR" && -d "$TEMP_TARGET_DIR" ]]; then
+    rm -rf -- "$TEMP_TARGET_DIR"
+  fi
+  TEMP_TARGET_DIR=""
+}
+trap cleanup_temp_target EXIT
+
+seconds_remaining() {
+  local deadline="$1"
+  local now
+  now="$(date +%s)"
+  ((now < deadline)) || return 1
+  echo $((deadline - now))
+}
+
+curl_bounded() {
+  local max_time="$1"
+  shift
+  local connect_time="$CURL_CONNECT_TIMEOUT_SECONDS"
+  if ((connect_time > max_time)); then
+    connect_time="$max_time"
+  fi
+  curl --connect-timeout "$connect_time" --max-time "$max_time" "$@"
+}
+
+cancel_project() {
+  local id="$1"
+  curl_bounded "$CURL_CANCEL_TIMEOUT_SECONDS" -sf -X POST \
+    "$HOST/api/projects/$id/cancel" >/dev/null 2>&1 || true
+}
+
+sha256_file() {
+  local path="$1"
+  if command -v shasum >/dev/null; then
+    shasum -a 256 -- "$path" | awk '{print $1}'
+  else
+    sha256sum -- "$path" | awk '{print $1}'
+  fi
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --fixtures|--synthetic)
+      MODE="synthetic"
+      shift
+      ;;
+    --timeout)
+      (($# >= 2)) || die "--timeout requires seconds"
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    --baseline)
+      (($# >= 2)) || die "--baseline requires a summary.json path"
+      BASELINE="$2"
+      shift 2
+      ;;
+    http://*|https://*)
+      HOST="$1"
+      shift
+      ;;
+    *)
+      die "unknown argument '$1' (use --help)"
+      ;;
+  esac
+done
+
+[[ "$TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || die "timeout must be a positive integer"
+[[ "$POLL_SECONDS" =~ ^[1-9][0-9]*$ ]] || die "poll interval must be a positive integer"
+command -v jq >/dev/null || die "jq is required (brew install jq)"
+if ! command -v shasum >/dev/null && ! command -v sha256sum >/dev/null; then
+  die "shasum or sha256sum is required for source fingerprints"
+fi
+
 shopt -s nullglob
-mp4s=("$SOURCES"/*.mp4 "$SOURCES"/*.m4v)
-[ ${#mp4s[@]} -gt 0 ] || { echo "No MP4s in $SOURCES — add golden-set episodes first (see evals/README.md)"; exit 1; }
-
+mkdir -p "$RESULTS_ROOT"
+RUN_DIR="$RESULTS_ROOT/$(date +%Y%m%d-%H%M%S)-$$"
 mkdir -p "$RUN_DIR"
+
+git_commit="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+git_branch="$(git -C "$REPO_ROOT" branch --show-current 2>/dev/null || echo unknown)"
+git_status="$(git -C "$REPO_ROOT" status --short 2>/dev/null || true)"
+git_diff_stat="$(git -C "$REPO_ROOT" diff --stat 2>/dev/null || true)"
+
+write_provenance() {
+  local app_setup="$1"
+  jq -n \
+    --arg commit "$git_commit" \
+    --arg branch "$git_branch" \
+    --arg status "$git_status" \
+    --arg diff_stat "$git_diff_stat" \
+    --arg repo_root "$REPO_ROOT" \
+    --arg host "$HOST" \
+    --arg mode "$MODE" \
+    --arg timeout "$TIMEOUT_SECONDS" \
+    --arg poll "$POLL_SECONDS" \
+    --arg baseline "$BASELINE" \
+    --arg results_root "$RESULTS_ROOT" \
+    --argjson app_setup "$app_setup" \
+    '{
+      commit: $commit,
+      branch: $branch,
+      worktree_status: $status,
+      diff_stat: $diff_stat,
+      repo_root: $repo_root,
+      config: {
+        host: $host,
+        mode: $mode,
+        timeout_seconds: ($timeout | tonumber),
+        poll_seconds: ($poll | tonumber),
+        baseline: (if $baseline == "" then null else $baseline end),
+        results_root: $results_root,
+        run_cargo_fixture_tests: (env.CF_EVAL_RUN_CARGO // "1")
+      },
+      app_setup: $app_setup
+    }' > "$RUN_DIR/provenance.json"
+}
+
+write_delta() {
+  local summary_file="$1"
+  local baseline_path="$BASELINE"
+  local baseline_json="null"
+  local candidate candidate_mode
+
+  if [[ -n "$baseline_path" ]]; then
+    [[ -f "$baseline_path" ]] || die "baseline summary not found: $baseline_path"
+  else
+    for candidate in "$RESULTS_ROOT"/*/summary.json; do
+      [[ "$candidate" == "$summary_file" ]] && continue
+      candidate_mode="$(jq -er '.mode // empty' "$candidate" 2>/dev/null || true)"
+      [[ "$candidate_mode" == "$MODE" ]] || continue
+      if [[ -z "$baseline_path" || "$candidate" > "$baseline_path" ]]; then
+        baseline_path="$candidate"
+      fi
+    done
+  fi
+
+  if [[ -n "$baseline_path" ]]; then
+    baseline_json="$(<"$baseline_path")"
+    jq -e . >/dev/null <<<"$baseline_json" || die "baseline is not valid JSON: $baseline_path"
+    candidate_mode="$(jq -r '.mode // empty' <<<"$baseline_json")"
+    [[ "$candidate_mode" == "$MODE" ]] || \
+      die "baseline mode '$candidate_mode' does not match current mode '$MODE': $baseline_path"
+  fi
+
+  local current_json
+  current_json="$(<"$summary_file")"
+  jq -n \
+    --argjson current "$current_json" \
+    --argjson baseline "$baseline_json" \
+    --arg baseline_path "$baseline_path" \
+    '{
+      baseline: (if $baseline == null then null else {path: $baseline_path, summary: $baseline} end),
+      current: $current,
+      delta: (
+        if $baseline == null then null
+        elif $current.mode == "real_media" and $baseline.mode == "real_media" then {
+          ready_clips: (($current.totals.ready_clips // 0) - ($baseline.totals.ready_clips // 0)),
+          failed_clips: (($current.totals.failed_clips // 0) - ($baseline.totals.failed_clips // 0)),
+          rejected_candidates: (($current.totals.rejected_candidates // 0) - ($baseline.totals.rejected_candidates // 0)),
+          terminal_failures: (($current.totals.terminal_failures // 0) - ($baseline.totals.terminal_failures // 0))
+        }
+        elif $current.mode == "synthetic" and $baseline.mode == "synthetic" then {
+          expected_accept: (($current.editorial_fixtures.expected_accept // 0) - ($baseline.editorial_fixtures.expected_accept // 0)),
+          expected_reject: (($current.editorial_fixtures.expected_reject // 0) - ($baseline.editorial_fixtures.expected_reject // 0)),
+          selector_test_changed: (($current.editorial_fixtures.selector_test // "") != ($baseline.editorial_fixtures.selector_test // "")),
+          overlap_test_changed: (($current.overlap_fixture.test // "") != ($baseline.overlap_fixture.test // ""))
+        }
+        else {error: "baseline mode does not match current mode"}
+        end
+      )
+    }' > "$RUN_DIR/delta.json"
+}
+
+run_synthetic() {
+  local editorial="$ROOT/fixtures/editorial_cases.json"
+  local overlap="$ROOT/fixtures/overlap_containment.json"
+  [[ -f "$editorial" ]] || die "missing fixture manifest: $editorial"
+  [[ -f "$overlap" ]] || die "missing fixture manifest: $overlap"
+
+  jq -e '
+    type == "array" and length > 0 and
+    all(.[];
+      (.name | type) == "string" and
+      ((.expected == "accept") or (.expected == "reject")) and
+      (.sentences | type) == "array" and (.sentences | length) > 0)
+  ' "$editorial" >/dev/null || die "invalid editorial fixture manifest"
+  jq -e '
+    (.name | type) == "string" and
+    (.higher_ranked.start_ms | type) == "number" and
+    (.higher_ranked.end_ms | type) == "number" and
+    (.lower_ranked.start_ms | type) == "number" and
+    (.lower_ranked.end_ms | type) == "number" and
+    (.expected | type) == "string"
+  ' "$overlap" >/dev/null || die "invalid overlap fixture manifest"
+
+  local total expected_accept expected_reject overlap_name overlap_expected
+  total="$(jq 'length' "$editorial")"
+  expected_accept="$(jq '[.[] | select(.expected == "accept")] | length' "$editorial")"
+  expected_reject="$(jq '[.[] | select(.expected == "reject")] | length' "$editorial")"
+  overlap_name="$(jq -r '.name' "$overlap")"
+  overlap_expected="$(jq -r '.expected' "$overlap")"
+
+  local selector_test="skipped" overlap_test="skipped"
+  if [[ "${CF_EVAL_RUN_CARGO:-1}" == "1" ]]; then
+    if command -v cargo >/dev/null; then
+      local target_dir
+      if [[ -n "${CF_EVAL_TARGET_DIR:-}" ]]; then
+        target_dir="$CF_EVAL_TARGET_DIR"
+      else
+        TEMP_TARGET_DIR="$(mktemp -d "${TMPDIR:-/tmp}/clipping-factory-evals-target.XXXXXX")"
+        target_dir="$TEMP_TARGET_DIR"
+      fi
+      mkdir -p "$target_dir"
+      if cargo test --locked --target-dir "$target_dir" \
+        select::heuristic::tests::synthetic_editorial_fixtures_match_selector_expectations \
+        -- --exact --nocapture > "$RUN_DIR/selector-test.log" 2>&1; then
+        selector_test="passed"
+      else
+        selector_test="failed"
+      fi
+      if cargo test --locked --target-dir "$target_dir" \
+        validate::tests::a_candidate_containing_a_higher_ranked_clip_is_rejected_as_overlap \
+        -- --exact --nocapture >> "$RUN_DIR/selector-test.log" 2>&1; then
+        overlap_test="passed"
+      else
+        overlap_test="failed"
+      fi
+      cleanup_temp_target
+    else
+      selector_test="cargo-not-found"
+      overlap_test="cargo-not-found"
+    fi
+  fi
+
+  local app_setup='null'
+  write_provenance "$app_setup"
+  jq -n \
+    --arg mode "$MODE" \
+    --argjson total "$total" \
+    --argjson expected_accept "$expected_accept" \
+    --argjson expected_reject "$expected_reject" \
+    --arg selector_test "$selector_test" \
+    --arg overlap_name "$overlap_name" \
+    --arg overlap_expected "$overlap_expected" \
+    --arg overlap_test "$overlap_test" \
+    '{
+      mode: $mode,
+      editorial_fixtures: {
+        total: $total,
+        expected_accept: $expected_accept,
+        expected_reject: $expected_reject,
+        selector_test: $selector_test
+      },
+      overlap_fixture: {
+        name: $overlap_name,
+        expected: $overlap_expected,
+        test: $overlap_test
+      }
+    }' > "$RUN_DIR/summary.json"
+  write_delta "$RUN_DIR/summary.json"
+  echo "Synthetic eval → $RUN_DIR"
+  echo "  $total editorial fixtures ($expected_accept expected accept, $expected_reject expected reject)"
+  echo "  selector test: $selector_test; overlap test: $overlap_test"
+  echo "  baseline/delta: $RUN_DIR/delta.json"
+  if [[ "$selector_test" != "passed" || "$overlap_test" != "passed" ]]; then
+    return 1
+  fi
+  return 0
+}
+
+if [[ "$MODE" == "synthetic" ]]; then
+  run_synthetic
+  exit $?
+fi
+
+setup_json=""
+if ! setup_json="$(curl_bounded "$TIMEOUT_SECONDS" -sf "$HOST/api/setup")"; then
+  die "Studio not reachable at $HOST — start it with: cargo run --release"
+fi
+jq -e . >/dev/null <<<"$setup_json" || die "Studio returned invalid JSON from /api/setup"
+write_provenance "$setup_json"
+
+mp4s=("$SOURCES"/*.mp4 "$SOURCES"/*.m4v)
+[[ ${#mp4s[@]} -gt 0 ]] || die "No MP4s in $SOURCES — add golden-set episodes first (see evals/README.md)"
+
 echo "Eval run → $RUN_DIR (${#mp4s[@]} source(s))"
+summary_sources='[]'
+run_failed=0
+source_index=0
 
 for src in "${mp4s[@]}"; do
+  source_index=$((source_index + 1))
   name="$(basename "$src")"
   echo ""
   echo "── $name"
-  id="$(curl -sf -X POST "$HOST/api/projects" -F "file=@$src" | jq -r '.project.id')"
+
+  started_epoch="$(date +%s)"
+  deadline=$((started_epoch + TIMEOUT_SECONDS))
+  source_sha256="$(sha256_file "$src")"
+  remaining=""
+  if ! remaining="$(seconds_remaining "$deadline")"; then
+    echo "   source fingerprinting exceeded the ${TIMEOUT_SECONDS}s deadline" >&2
+    summary_sources="$(jq -c --arg source "$name" --arg sha256 "$source_sha256" '. + [{source: $source, source_sha256: $sha256, status: "upload_timeout", terminal: false, ready_clips: 0, failed_clips: 0, rejected_candidates: 0}]' <<<"$summary_sources")"
+    run_failed=1
+    continue
+  fi
+
+  project_json=""
+  if ! project_json="$(curl_bounded "$remaining" -sf -X POST "$HOST/api/projects" -F "file=@$src")"; then
+    if seconds_remaining "$deadline" >/dev/null; then
+      status="upload_failed"
+      echo "   upload failed" >&2
+    else
+      status="upload_timeout"
+      echo "   upload exceeded the ${TIMEOUT_SECONDS}s deadline" >&2
+    fi
+    summary_sources="$(jq -c --arg source "$name" --arg sha256 "$source_sha256" --arg status "$status" '. + [{source: $source, source_sha256: $sha256, status: $status, terminal: false, ready_clips: 0, failed_clips: 0, rejected_candidates: 0}]' <<<"$summary_sources")"
+    run_failed=1
+    continue
+  fi
+  if ! id="$(jq -er '.project.id // empty' <<<"$project_json")"; then
+    echo "   upload response had no project id" >&2
+    summary_sources="$(jq -c --arg source "$name" --arg sha256 "$source_sha256" '. + [{source: $source, source_sha256: $sha256, status: "upload_failed", terminal: false, ready_clips: 0, failed_clips: 0, rejected_candidates: 0}]' <<<"$summary_sources")"
+    run_failed=1
+    continue
+  fi
   echo "   project $id — processing…"
 
   status="created"
+  terminal=false
+  failure=""
+  view='{}'
   while :; do
-    sleep 5
-    view="$(curl -sf "$HOST/api/projects/$id")"
-    status="$(jq -r '.project.status' <<<"$view")"
+    remaining=""
+    if ! remaining="$(seconds_remaining "$deadline")"; then
+      status="timeout"
+      failure="project did not reach a terminal status within ${TIMEOUT_SECONDS}s"
+      cancel_project "$id"
+      run_failed=1
+      break
+    fi
+    sleep_for="$POLL_SECONDS"
+    if ((sleep_for > remaining)); then
+      sleep_for="$remaining"
+    fi
+    sleep "$sleep_for"
+    if ! remaining="$(seconds_remaining "$deadline")"; then
+      status="timeout"
+      failure="project did not reach a terminal status within ${TIMEOUT_SECONDS}s"
+      cancel_project "$id"
+      run_failed=1
+      break
+    fi
+    if ! view="$(curl_bounded "$remaining" -sf "$HOST/api/projects/$id")"; then
+      if seconds_remaining "$deadline" >/dev/null; then
+        status="api_error"
+        failure="project view request failed"
+      else
+        status="timeout"
+        failure="project did not reach a terminal status within ${TIMEOUT_SECONDS}s"
+      fi
+      cancel_project "$id"
+      run_failed=1
+      break
+    fi
+    if ! status="$(jq -er '.project.status // empty' <<<"$view")"; then
+      status="invalid_project_view"
+      failure="project view did not contain project.status"
+      cancel_project "$id"
+      run_failed=1
+      break
+    fi
     case "$status" in
-      complete|failed|cancelled) break ;;
-      *) printf '   %s\r' "$status" ;;
+      complete)
+        terminal=true
+        break
+        ;;
+      failed|cancelled)
+        terminal=true
+        failure="terminal project status: $status"
+        run_failed=1
+        break
+        ;;
+      *)
+        printf '   %s\r' "$status"
+        ;;
     esac
   done
 
-  out="$RUN_DIR/${name%.*}"
+  finished_epoch="$(date +%s)"
+  elapsed_seconds=$((finished_epoch - started_epoch))
+  out="$RUN_DIR/project-$(printf '%03d' "$source_index")"
   mkdir -p "$out"
-  jq . <<<"$view" > "$out/view.json"
-  jq -r '"   → \(.project.status): \(.clips | map(select(.status=="ready")) | length) clip(s) ready, \(.rejected) rejected candidate(s), selector: \(.selector // "n/a")"' <<<"$view"
+  if ! jq . <<<"$view" > "$out/view.json"; then
+    jq -n --arg status "$status" --arg failure "$failure" \
+      '{project: {status: $status, error: $failure}}' > "$out/view.json"
+  fi
+
+  ready_clips="$(jq -r '(.clips // []) | map(select(.status == "ready")) | length' <<<"$view" 2>/dev/null || echo 0)"
+  failed_clips="$(jq -r '(.clips // []) | map(select(.status == "failed")) | length' <<<"$view" 2>/dev/null || echo 0)"
+  rejected_candidates="$(jq -r '.rejected // 0' <<<"$view" 2>/dev/null || echo 0)"
+  selector="$(jq -r '.selector // .project.selector // "n/a"' <<<"$view" 2>/dev/null || echo n/a)"
+  if ((failed_clips > 0)); then
+    run_failed=1
+    if [[ -z "$failure" ]]; then
+      failure="$failed_clips clip(s) failed to render"
+    fi
+  fi
+  echo "   → $status: $ready_clips clip(s) ready, $failed_clips failed, $rejected_candidates rejected candidate(s), selector: $selector"
+  [[ -z "$failure" ]] || echo "   failure: $failure" >&2
+
+  summary_sources="$(jq -c \
+    --arg source "$name" \
+    --arg source_sha256 "$source_sha256" \
+    --arg project "$id" \
+    --arg status "$status" \
+    --arg selector "$selector" \
+    --arg failure "$failure" \
+    --argjson terminal "$terminal" \
+    --argjson elapsed "$elapsed_seconds" \
+    --argjson ready "$ready_clips" \
+    --argjson failed "$failed_clips" \
+    --argjson rejected "$rejected_candidates" \
+    '. + [{source: $source, source_sha256: $source_sha256, project_id: $project, status: $status, terminal: $terminal, elapsed_seconds: $elapsed, ready_clips: $ready, failed_clips: $failed, rejected_candidates: $rejected, selector: $selector, failure: (if $failure == "" then null else $failure end)}]' \
+    <<<"$summary_sources")"
 done
 
+totals="$(jq -c '
+  {
+    sources: length,
+    terminal_failures: map(select(.status == "failed" or .status == "cancelled" or .status == "timeout" or .status == "api_error" or .status == "invalid_project_view" or .status == "upload_failed" or .status == "upload_timeout")) | length,
+    ready_clips: (map(.ready_clips // 0) | add // 0),
+    failed_clips: (map(.failed_clips // 0) | add // 0),
+    rejected_candidates: (map(.rejected_candidates // 0) | add // 0)
+  }
+' <<<"$summary_sources")"
+jq -n \
+  --arg mode "$MODE" \
+  --arg host "$HOST" \
+  --argjson sources "$summary_sources" \
+  --argjson totals "$totals" \
+  '{mode: $mode, host: $host, sources: $sources, totals: $totals}' > "$RUN_DIR/summary.json"
+
 cp "$ROOT/rubric.csv" "$RUN_DIR/rubric.csv"
+write_delta "$RUN_DIR/summary.json"
 echo ""
 echo "Done. Watch every clip, then score $RUN_DIR/rubric.csv (see evals/README.md)."
+echo "Summary: $RUN_DIR/summary.json"
+echo "Delta:   $RUN_DIR/delta.json"
+if ((run_failed)); then
+  echo "Eval failed: at least one source did not complete successfully." >&2
+  exit 1
+fi

--- a/src/api.rs
+++ b/src/api.rs
@@ -219,6 +219,15 @@ struct UploadFields {
     framing_mode: FramingMode,
 }
 
+const UPLOAD_DISK_RESERVE_BYTES: u64 = 1024 * 1024 * 1024;
+
+fn upload_capacity_bytes(free_gb: Option<f64>) -> Option<u64> {
+    free_gb.map(|gb| {
+        let free_bytes = (gb.max(0.0) * 1024.0 * 1024.0 * 1024.0) as u64;
+        free_bytes.saturating_sub(UPLOAD_DISK_RESERVE_BYTES)
+    })
+}
+
 async fn cleanup_upload(state: &AppState, id: &str) {
     tokio::fs::remove_dir_all(state.store.project_dir(id))
         .await
@@ -261,6 +270,8 @@ async fn receive_upload(
 ) -> Result<UploadFields, ApiError> {
     state.store.create_dirs(id).await.map_err(ApiError::from)?;
     let dest = state.store.source_path(id);
+    let upload_capacity =
+        upload_capacity_bytes(crate::util::disk_free_gb(&state.cfg.data_dir).await);
 
     let mut original_name = String::new();
     let mut wrote_bytes: u64 = 0;
@@ -333,7 +344,13 @@ async fn receive_upload(
             .await
             .map_err(|e| bad_request(format!("upload interrupted: {e}")))?
         {
-            wrote_bytes += chunk.len() as u64;
+            let next_size = wrote_bytes.saturating_add(chunk.len() as u64);
+            if upload_capacity.is_some_and(|capacity| next_size > capacity) {
+                return Err(bad_request(
+                    "Not enough free disk space for this video. Free up space and try again.",
+                ));
+            }
+            wrote_bytes = next_size;
             file.write_all(&chunk)
                 .await
                 .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
@@ -1024,6 +1041,16 @@ mod tests {
         let multiple = axum::http::HeaderValue::from_static("bytes=0-1,4-5");
         assert!(parse_byte_range(Some(&beyond), 100).is_err());
         assert!(parse_byte_range(Some(&multiple), 100).is_err());
+    }
+
+    #[test]
+    fn upload_capacity_keeps_one_gibibyte_free() {
+        assert_eq!(
+            upload_capacity_bytes(Some(3.0)),
+            Some(2 * 1024 * 1024 * 1024)
+        );
+        assert_eq!(upload_capacity_bytes(Some(0.5)), Some(0));
+        assert_eq!(upload_capacity_bytes(None), None);
     }
 
     #[tokio::test]

--- a/src/api.rs
+++ b/src/api.rs
@@ -28,6 +28,7 @@ use axum::{Json, Router};
 use futures::stream::{self, Stream, StreamExt};
 use serde_json::json;
 use std::convert::Infallible;
+use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -173,15 +174,18 @@ async fn set_settings(
         ));
     }
     let updated = {
-        let mut s = state.settings.write().unwrap();
-        s.provider = body.provider;
-        s.model = body.model;
+        let mut candidate = state.settings.read().unwrap().clone();
+        candidate.provider = body.provider;
+        candidate.model = body.model;
         // Empty key = keep the existing one (lets users switch model without retyping).
         if !body.api_key.trim().is_empty() {
-            s.api_key = Some(body.api_key.trim().to_string());
+            candidate.api_key = Some(body.api_key.trim().to_string());
         }
-        s.clone()
+        candidate
     };
+    crate::select::test_connection(&updated)
+        .await
+        .map_err(|e| ApiError(StatusCode::BAD_REQUEST, e.to_string()))?;
     // `settings::save` touches the filesystem synchronously (write + chmod
     // 0600) — keep that work off the async workers.
     let data_dir = state.cfg.data_dir.clone();
@@ -190,6 +194,7 @@ async fn set_settings(
         .await
         .map_err(|e| ApiError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .map_err(|e| ApiError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    *state.settings.write().unwrap() = updated.clone();
     Ok(Json(
         serde_json::to_value(updated.public()).unwrap_or_default(),
     ))
@@ -207,13 +212,55 @@ async fn test_settings(State(state): State<AppState>) -> Json<serde_json::Value>
 // Projects
 // ---------------------------------------------------------------------------
 
-async fn create_project(
-    State(state): State<AppState>,
+struct UploadFields {
+    original_name: String,
+    caption_style: Option<String>,
+    accent_color: Option<String>,
+    framing_mode: FramingMode,
+}
+
+async fn cleanup_upload(state: &AppState, id: &str) {
+    tokio::fs::remove_dir_all(state.store.project_dir(id))
+        .await
+        .ok();
+}
+
+struct UploadCleanupGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl UploadCleanupGuard {
+    fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for UploadCleanupGuard {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        let path = self.path.clone();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                tokio::fs::remove_dir_all(path).await.ok();
+            });
+        }
+    }
+}
+
+async fn receive_upload(
+    state: &AppState,
+    id: &str,
     mut multipart: Multipart,
-) -> Result<Json<serde_json::Value>, ApiError> {
-    let id = crate::util::short_id();
-    state.store.create_dirs(&id).await.map_err(ApiError::from)?;
-    let dest = state.store.source_path(&id);
+) -> Result<UploadFields, ApiError> {
+    state.store.create_dirs(id).await.map_err(ApiError::from)?;
+    let dest = state.store.source_path(id);
 
     let mut original_name = String::new();
     let mut wrote_bytes: u64 = 0;
@@ -243,7 +290,7 @@ async fn create_project(
                     accent_color = Some(if v.starts_with('#') {
                         v
                     } else {
-                        format!("#{}", v)
+                        format!("#{v}")
                     });
                 }
             }
@@ -251,17 +298,9 @@ async fn create_project(
         }
         if field.name() == Some("accent_mode") {
             if let Ok(v) = field.text().await {
-                accent_mode = match crate::accent::AccentMode::parse(&v) {
-                    Some(mode) => mode,
-                    None => {
-                        tokio::fs::remove_dir_all(state.store.project_dir(&id))
-                            .await
-                            .ok();
-                        return Err(bad_request(
-                            "accent_mode must be manual, random, or optimized",
-                        ));
-                    }
-                };
+                accent_mode = crate::accent::AccentMode::parse(&v).ok_or_else(|| {
+                    bad_request("accent_mode must be manual, random, or optimized")
+                })?;
             }
             continue;
         }
@@ -280,15 +319,13 @@ async fn create_project(
         original_name = field.file_name().unwrap_or("source.mp4").to_string();
         let lower = original_name.to_lowercase();
         if !(lower.ends_with(".mp4") || lower.ends_with(".m4v")) {
-            tokio::fs::remove_dir_all(state.store.project_dir(&id))
-                .await
-                .ok();
             return Err(bad_request(
                 "Attach an .mp4 file. Other containers are post-MVP.",
             ));
         }
         // Stream to disk without buffering the whole video in memory (PRD §7.2).
-        let mut file = tokio::fs::File::create(&dest)
+        let upload_temp = crate::util::unique_temp_path(&dest);
+        let mut file = tokio::fs::File::create(&upload_temp)
             .await
             .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
         while let Some(chunk) = field
@@ -301,13 +338,15 @@ async fn create_project(
                 .await
                 .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
         }
-        file.flush().await.ok();
+        file.flush()
+            .await
+            .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
+        crate::util::promote_atomic(&upload_temp, &dest)
+            .await
+            .map_err(ApiError::from)?;
     }
 
     if wrote_bytes == 0 {
-        tokio::fs::remove_dir_all(state.store.project_dir(&id))
-            .await
-            .ok();
         return Err(bad_request(
             "No file received. Drop one MP4 into the studio.",
         ));
@@ -334,26 +373,50 @@ async fn create_project(
         crate::accent::AccentMode::Manual => accent_color,
     };
 
-    let mut project = Project::new(id.clone(), dest);
-    project.caption_style = caption_style;
-    project.accent_color = accent_color;
-    project.framing_mode = framing_mode;
-    state
-        .store
-        .save_project(&project)
-        .await
-        .map_err(ApiError::from)?;
+    Ok(UploadFields {
+        original_name,
+        caption_style,
+        accent_color,
+        framing_mode,
+    })
+}
+
+async fn create_project(
+    State(state): State<AppState>,
+    multipart: Multipart,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    let id = crate::util::short_id();
+    let mut cleanup = UploadCleanupGuard::new(state.store.project_dir(&id));
+    let fields = match receive_upload(&state, &id, multipart).await {
+        Ok(fields) => fields,
+        Err(error) => {
+            cleanup_upload(&state, &id).await;
+            cleanup.disarm();
+            return Err(error);
+        }
+    };
+
+    let mut project = Project::new(id.clone(), state.store.source_path(&id));
+    project.caption_style = fields.caption_style;
+    project.accent_color = fields.accent_color;
+    project.framing_mode = fields.framing_mode;
+    if let Err(error) = state.store.save_project(&project).await {
+        cleanup_upload(&state, &id).await;
+        cleanup.disarm();
+        return Err(ApiError::from(error));
+    }
+    cleanup.disarm();
     // The original filename lives in a sidecar file; the inspect stage and
     // output-folder naming read it from there.
     tokio::fs::write(
         state.store.project_dir(&id).join("original-name.txt"),
-        &original_name,
+        &fields.original_name,
     )
     .await
     .ok();
 
     // Processing begins automatically (PRD §7.2).
-    pipeline::start(state.clone(), id.clone()).ok();
+    pipeline::start(state.clone(), id.clone()).await.ok();
 
     let view = project_view(&state, &id).await.map_err(ApiError::from)?;
     Ok(Json(view))
@@ -446,7 +509,7 @@ async fn process_project(
     if !state.store.exists(&id) {
         return Err(not_found("Project not found."));
     }
-    match pipeline::start(state.clone(), id) {
+    match pipeline::start(state.clone(), id).await {
         Ok(()) => Ok(Json(json!({ "started": true }))),
         Err(msg) => Err(ApiError(StatusCode::CONFLICT, msg)),
     }
@@ -459,8 +522,21 @@ async fn cancel_project(
     if !state.store.exists(&id) {
         return Err(not_found("Project not found."));
     }
-    let was_running = pipeline::cancel(&state, &id);
-    Ok(Json(json!({ "cancelling": was_running })))
+    match pipeline::cancel(&state, &id)
+        .await
+        .map_err(|msg| ApiError(StatusCode::INTERNAL_SERVER_ERROR, msg))?
+    {
+        pipeline::CancelOutcome::Cancelled => Ok(Json(json!({
+            "cancelling": false,
+            "cancelled": true,
+            "status": "cancelled"
+        }))),
+        pipeline::CancelOutcome::Status(status) => Ok(Json(json!({
+            "cancelling": false,
+            "cancelled": false,
+            "status": status
+        }))),
+    }
 }
 
 async fn retry_project(
@@ -545,7 +621,9 @@ async fn restyle_clip(
     if !state.store.exists(&id) {
         return Err(not_found("Project not found."));
     }
-    if state.handle(&id).is_running() {
+    let handle = state.handle(&id);
+    let _operation = handle.operation.lock().await;
+    if handle.is_running() {
         return Err(ApiError(
             StatusCode::CONFLICT,
             "Processing is still running. Restyle clips once rendering finishes.".into(),
@@ -629,7 +707,25 @@ async fn restyle_clip(
     // Ensure the framed, uncaptioned base exists (projects rendered before
     // base intermediates existed rebuild it here from the source, one time).
     let base_path = state.store.base_clip_path(&id, &clip.id);
-    if !base_path.is_file() {
+    let mut base_ready = state
+        .store
+        .base_is_ready(&id, &clip.id)
+        .await
+        .map_err(ApiError::from)?;
+    if !base_ready
+        && tokio::fs::metadata(&base_path)
+            .await
+            .map(|m| m.is_file() && m.len() > 0)
+            .unwrap_or(false)
+    {
+        state
+            .store
+            .mark_base_ready(&id, &clip.id)
+            .await
+            .map_err(ApiError::from)?;
+        base_ready = true;
+    }
+    if !base_ready {
         let source = p.source.clone().ok_or_else(|| {
             ApiError(
                 StatusCode::CONFLICT,
@@ -645,6 +741,9 @@ async fn restyle_clip(
         tokio::fs::create_dir_all(state.store.base_dir(&id))
             .await
             .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
+        tokio::fs::remove_file(&base_path).await.ok();
+        state.store.clear_base_ready(&id, &clip.id).await;
+        let base_temp = crate::util::unique_temp_path(&base_path);
         crate::render::render_base_clip(
             cfg,
             &p.source_path,
@@ -652,12 +751,20 @@ async fn restyle_clip(
             &clip.layout,
             clip.start_ms,
             clip.end_ms,
-            &base_path,
+            &base_temp,
             &cancel,
             |_| {},
         )
         .await
         .map_err(ApiError::from)?;
+        crate::util::promote_atomic(&base_temp, &base_path)
+            .await
+            .map_err(ApiError::from)?;
+        state
+            .store
+            .mark_base_ready(&id, &clip.id)
+            .await
+            .map_err(ApiError::from)?;
     }
 
     // Build the new captions and burn them onto the base.
@@ -674,8 +781,10 @@ async fn restyle_clip(
         style,
     );
     let clips_dir = state.store.clips_dir(&id);
-    let ass_path = clips_dir.join(format!("{}.restyle.ass", clip.id));
-    let tmp_out = clips_dir.join(format!("{}.restyle.tmp.mp4", clip.id));
+    let final_path = clips_dir.join(&clip.filename);
+    let ass_path =
+        crate::util::unique_temp_path(&clips_dir.join(format!("{}.restyle.ass", clip.id)));
+    let tmp_out = crate::util::unique_temp_path(&final_path);
     tokio::fs::write(&ass_path, &ass)
         .await
         .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
@@ -695,12 +804,16 @@ async fn restyle_clip(
         return Err(ApiError::from(e));
     }
 
-    // Swap the restyled clip into place, then refresh the copy in the
+    // Atomically promote the restyled clip into place, then refresh the copy in the
     // user-facing output folder (best-effort, mirroring the render stage).
-    let final_path = clips_dir.join(&clip.filename);
-    tokio::fs::rename(&tmp_out, &final_path)
+    crate::util::promote_atomic(&tmp_out, &final_path)
         .await
-        .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
+        .map_err(ApiError::from)?;
+    state
+        .store
+        .mark_final_ready(&id, &clip.id)
+        .await
+        .map_err(ApiError::from)?;
     if let Some(dir) = manifest.output_dir.clone() {
         tokio::fs::copy(&final_path, std::path::Path::new(&dir).join(&clip.filename))
             .await
@@ -715,9 +828,7 @@ async fn restyle_clip(
         .save_manifest(&id, &manifest)
         .await
         .map_err(ApiError::from)?;
-    state
-        .handle(&id)
-        .emit(json!({"type": "clip", "clip": manifest.clips[idx]}));
+    handle.emit(json!({"type": "clip", "clip": manifest.clips[idx]}));
     Ok(Json(
         serde_json::to_value(&manifest.clips[idx]).unwrap_or_default(),
     ))
@@ -776,6 +887,7 @@ async fn serve_video(
     download_name: Option<String>,
 ) -> Result<Response, ApiError> {
     use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    use tokio_util::io::ReaderStream;
     let mut file = tokio::fs::File::open(path)
         .await
         .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
@@ -786,24 +898,7 @@ async fn serve_video(
         .len();
 
     // Parse a simple `bytes=start-end` range.
-    let range = headers
-        .get(header::RANGE)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.strip_prefix("bytes="))
-        .and_then(|spec| {
-            let (a, b) = spec.split_once('-')?;
-            let start: u64 = a.parse().ok()?;
-            let end: u64 = if b.is_empty() {
-                len.saturating_sub(1)
-            } else {
-                b.parse().ok()?
-            };
-            if start > end || end >= len {
-                None
-            } else {
-                Some((start, end))
-            }
-        });
+    let range = parse_byte_range(headers.get(header::RANGE), len);
 
     let mut builder = Response::builder()
         .header(header::ACCEPT_RANGES, "bytes")
@@ -819,26 +914,24 @@ async fn serve_video(
     }
 
     let (start, end, status) = match range {
-        Some((s, e)) => (s, e, StatusCode::PARTIAL_CONTENT),
-        None => (0, len.saturating_sub(1), StatusCode::OK),
+        Ok(Some((s, e))) => (s, e, StatusCode::PARTIAL_CONTENT),
+        Ok(None) if len > 0 => (0, len - 1, StatusCode::OK),
+        _ => {
+            return Response::builder()
+                .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                .header(header::CONTENT_RANGE, format!("bytes */{len}"))
+                .body(axum::body::Body::empty())
+                .map_err(|e| ApiError::from(anyhow::Error::from(e)));
+        }
     };
     let read_len = end - start + 1;
     file.seek(std::io::SeekFrom::Start(start))
         .await
         .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
 
-    // Read the requested window in one buffered pass (clips are tens of MB max;
-    // range requests keep individual reads small during scrubbing).
-    let mut buf = Vec::with_capacity(read_len.min(64 * 1024 * 1024) as usize);
-    let mut limited = file.take(read_len);
-    limited
-        .read_to_end(&mut buf)
-        .await
-        .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
-
     builder = builder
         .status(status)
-        .header(header::CONTENT_LENGTH, buf.len().to_string());
+        .header(header::CONTENT_LENGTH, read_len.to_string());
     if status == StatusCode::PARTIAL_CONTENT {
         builder = builder.header(
             header::CONTENT_RANGE,
@@ -846,8 +939,49 @@ async fn serve_video(
         );
     }
     builder
-        .body(axum::body::Body::from(buf))
+        .body(axum::body::Body::from_stream(ReaderStream::new(
+            file.take(read_len),
+        )))
         .map_err(|e| ApiError::from(anyhow::Error::from(e)))
+}
+
+fn parse_byte_range(
+    value: Option<&axum::http::HeaderValue>,
+    len: u64,
+) -> Result<Option<(u64, u64)>, ()> {
+    let Some(value) = value else { return Ok(None) };
+    if len == 0 {
+        return Err(());
+    }
+    let spec = value
+        .to_str()
+        .map_err(|_| ())?
+        .strip_prefix("bytes=")
+        .ok_or(())?;
+    if spec.contains(',') {
+        return Err(());
+    }
+    let (start, end) = spec.split_once('-').ok_or(())?;
+    if start.is_empty() {
+        let suffix: u64 = end.parse().map_err(|_| ())?;
+        if suffix == 0 {
+            return Err(());
+        }
+        return Ok(Some((len.saturating_sub(suffix.min(len)), len - 1)));
+    }
+    let start: u64 = start.parse().map_err(|_| ())?;
+    if start >= len {
+        return Err(());
+    }
+    let end = if end.is_empty() {
+        len - 1
+    } else {
+        end.parse::<u64>().map_err(|_| ())?.min(len - 1)
+    };
+    if end < start {
+        return Err(());
+    }
+    Ok(Some((start, end)))
 }
 
 // ---------------------------------------------------------------------------
@@ -867,4 +1001,88 @@ async fn open_output_folder(
     };
     let opened = std::process::Command::new(opener).arg(&dir).spawn().is_ok();
     Ok(Json(json!({ "opened": opened, "path": dir })))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, Bytes};
+    use axum::extract::FromRequest;
+    use axum::http::Request;
+
+    #[test]
+    fn byte_ranges_support_open_ended_and_suffix_requests() {
+        let open = axum::http::HeaderValue::from_static("bytes=10-");
+        let suffix = axum::http::HeaderValue::from_static("bytes=-20");
+        assert_eq!(parse_byte_range(Some(&open), 100), Ok(Some((10, 99))));
+        assert_eq!(parse_byte_range(Some(&suffix), 100), Ok(Some((80, 99))));
+    }
+
+    #[test]
+    fn byte_ranges_reject_unsatisfiable_and_multiple_requests() {
+        let beyond = axum::http::HeaderValue::from_static("bytes=100-");
+        let multiple = axum::http::HeaderValue::from_static("bytes=0-1,4-5");
+        assert!(parse_byte_range(Some(&beyond), 100).is_err());
+        assert!(parse_byte_range(Some(&multiple), 100).is_err());
+    }
+
+    #[tokio::test]
+    async fn video_range_response_caps_end_and_streams_only_requested_bytes() {
+        let tmp = std::env::temp_dir().join(format!("cf-range-{}", crate::util::short_id()));
+        tokio::fs::create_dir_all(&tmp).await.unwrap();
+        let path = tmp.join("clip.mp4");
+        tokio::fs::write(&path, b"0123456789").await.unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(header::RANGE, "bytes=4-99".parse().unwrap());
+
+        let response = match serve_video(&path, &headers, None).await {
+            Ok(response) => response,
+            Err(_) => panic!("range response should be served"),
+        };
+
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT);
+        assert_eq!(response.headers()[header::CONTENT_RANGE], "bytes 4-9/10");
+        assert_eq!(response.headers()[header::CONTENT_LENGTH], "6");
+        let body = axum::body::to_bytes(response.into_body(), 6).await.unwrap();
+        assert_eq!(&body[..], b"456789");
+
+        tokio::fs::remove_dir_all(tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn interrupted_multipart_upload_removes_the_project_directory() {
+        let boundary = "cf-upload-boundary";
+        let prefix = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"source.mp4\"\r\nContent-Type: video/mp4\r\n\r\npartial"
+        );
+        let body = futures::stream::iter(vec![
+            Ok::<Bytes, std::io::Error>(Bytes::from(prefix)),
+            Err(std::io::Error::new(
+                std::io::ErrorKind::ConnectionAborted,
+                "client disconnected",
+            )),
+        ]);
+        let request = Request::builder()
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from_stream(body))
+            .unwrap();
+        let multipart = Multipart::from_request(request, &()).await.unwrap();
+
+        let tmp = std::env::temp_dir().join(format!("cf-upload-{}", crate::util::short_id()));
+        let mut cfg = crate::config::Config::resolve();
+        cfg.data_dir = tmp.join("data");
+        cfg.output_root = tmp.join("output");
+        let projects_dir = cfg.data_dir.join("projects");
+        let state = AppState::new(cfg);
+
+        assert!(create_project(State(state.clone()), multipart)
+            .await
+            .is_err());
+        let mut projects = tokio::fs::read_dir(projects_dir).await.unwrap();
+        assert!(projects.next_entry().await.unwrap().is_none());
+        tokio::fs::remove_dir_all(tmp).await.ok();
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,16 +10,14 @@
 //! - `CF_FONTS_DIR`       — directory containing caption fonts
 //! - `CF_FACE_MODEL`      — rustface seeta model path
 //! - `CF_THREADS`         — transcription threads (default = physical cores)
-//! - `CF_BIND_ALL=1`      — listen on 0.0.0.0 instead of 127.0.0.1
 //! - `CF_NO_OPEN=1`       — don't try to open the browser on start
 
 use crate::util::which;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[derive(Clone, Debug)]
 pub struct Config {
     pub port: u16,
-    pub bind_all: bool,
     pub open_browser: bool,
     pub data_dir: PathBuf,
     pub output_root: PathBuf,
@@ -43,6 +41,15 @@ fn env_path(key: &str) -> Option<PathBuf> {
 
 fn first_existing(cands: Vec<PathBuf>) -> Option<PathBuf> {
     cands.into_iter().find(|p| p.is_file())
+}
+
+fn find_whisper_model(data_dir: &Path, cwd: &Path) -> Option<PathBuf> {
+    first_existing(vec![
+        data_dir.join("models/ggml-small.en.bin"),
+        data_dir.join("models/ggml-base.en.bin"),
+        cwd.join("models/ggml-base.en.bin"),
+        cwd.join("../models/ggml-base.en.bin"),
+    ])
 }
 
 impl Config {
@@ -90,14 +97,7 @@ impl Config {
         // Model: env → data dir → common local locations.
         let whisper_model = env_path("CF_WHISPER_MODEL")
             .filter(|p| p.is_file())
-            .or_else(|| {
-                first_existing(vec![
-                    data_dir.join("models/ggml-base.en.bin"),
-                    data_dir.join("models/ggml-small.en.bin"),
-                    cwd.join("models/ggml-base.en.bin"),
-                    cwd.join("../models/ggml-base.en.bin"),
-                ])
-            });
+            .or_else(|| find_whisper_model(&data_dir, &cwd));
 
         // Caption fonts: bundled assets dir preferred.
         let fonts_dir = env_path("CF_FONTS_DIR").filter(|p| p.is_dir()).or_else(|| {
@@ -149,9 +149,6 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(4571),
-            bind_all: std::env::var("CF_BIND_ALL")
-                .map(|v| v == "1")
-                .unwrap_or(false),
             open_browser: std::env::var("CF_NO_OPEN")
                 .map(|v| v != "1")
                 .unwrap_or(true),
@@ -171,5 +168,25 @@ impl Config {
 
     pub fn projects_dir(&self) -> PathBuf {
         self.data_dir.join("projects")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_model_is_preferred_when_base_and_small_are_available() {
+        let root = std::env::temp_dir().join(format!("cf-config-test-{}", uuid::Uuid::new_v4()));
+        let models = root.join("models");
+        std::fs::create_dir_all(&models).unwrap();
+        let small = models.join("ggml-small.en.bin");
+        let base = models.join("ggml-base.en.bin");
+        std::fs::write(&base, b"base").unwrap();
+        std::fs::write(&small, b"small").unwrap();
+
+        assert_eq!(find_whisper_model(&root, &root), Some(small));
+
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/src/frame.rs
+++ b/src/frame.rs
@@ -17,9 +17,11 @@
 use crate::config::Config;
 use crate::domain::{CropKey, LayoutPlan, SourceInfo};
 use crate::util::run_streaming;
-use anyhow::Result;
+use anyhow::{bail, Result};
 use rustface::ImageData;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 const SAMPLE_FPS: f64 = 1.0;
@@ -78,10 +80,22 @@ pub async fn analyze_layout(
     // 2. List frames + detect faces (blocking CPU/fs work off the runtime).
     let model_path = model_path.clone();
     let dir = frames_dir.to_path_buf();
-    let detections: Vec<Vec<f32>> =
-        tokio::task::spawn_blocking(move || detect_all(&model_path, &dir)).await??;
-
+    let cancelled = Arc::new(AtomicBool::new(cancel.is_cancelled()));
+    let watcher_flag = cancelled.clone();
+    let watcher_token = cancel.clone();
+    let watcher = tokio::spawn(async move {
+        watcher_token.cancelled().await;
+        watcher_flag.store(true, Ordering::Relaxed);
+    });
+    let worker_flag = cancelled.clone();
+    let detection_result =
+        tokio::task::spawn_blocking(move || detect_all(&model_path, &dir, &worker_flag)).await;
+    watcher.abort();
     tokio::fs::remove_dir_all(frames_dir).await.ok();
+    let detections: Vec<Vec<f32>> = detection_result??;
+    if cancelled.load(Ordering::Relaxed) || cancel.is_cancelled() {
+        bail!("cancelled");
+    }
     if detections.is_empty() {
         return Ok(LayoutPlan::BlurPad);
     }
@@ -100,7 +114,14 @@ pub async fn analyze_layout(
 /// Per frame, return the normalized x-centers (0–1) of detected faces.
 /// Runs inside `spawn_blocking`: directory listing and detection are
 /// synchronous CPU/fs work that must stay off the async runtime.
-fn detect_all(model_path: &Path, frames_dir: &Path) -> Result<Vec<Vec<f32>>> {
+fn detect_all(
+    model_path: &Path,
+    frames_dir: &Path,
+    cancelled: &AtomicBool,
+) -> Result<Vec<Vec<f32>>> {
+    if cancelled.load(Ordering::Relaxed) {
+        bail!("cancelled");
+    }
     let mut frames: Vec<PathBuf> = std::fs::read_dir(frames_dir)?
         .flatten()
         .map(|e| e.path())
@@ -117,6 +138,9 @@ fn detect_all(model_path: &Path, frames_dir: &Path) -> Result<Vec<Vec<f32>>> {
 
     let mut out = Vec::with_capacity(frames.len());
     for path in &frames {
+        if cancelled.load(Ordering::Relaxed) {
+            bail!("cancelled");
+        }
         let centers = match image::open(path) {
             Ok(img) => {
                 let gray = img.to_luma8();
@@ -346,5 +370,16 @@ mod tests {
             }
             other => panic!("expected FaceCrop, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn face_detection_checks_cancellation_before_blocking_work() {
+        let cancelled = AtomicBool::new(true);
+        let result = detect_all(
+            Path::new("missing-model"),
+            Path::new("missing-frames"),
+            &cancelled,
+        );
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,7 @@ async fn main() -> anyhow::Result<()> {
     let state = AppState::new(cfg.clone());
     let app = api::router(state);
 
-    let host = if cfg.bind_all { "0.0.0.0" } else { "127.0.0.1" };
-    let addr = format!("{}:{}", host, cfg.port);
+    let addr = format!("127.0.0.1:{}", cfg.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     let url = format!("http://localhost:{}", cfg.port);
     println!("\n  Clipping Factory studio ready → {}\n", url);

--- a/src/media.rs
+++ b/src/media.rs
@@ -4,7 +4,7 @@
 
 use crate::config::Config;
 use crate::domain::SourceInfo;
-use crate::util::{run_capture, run_streaming};
+use crate::util::run_streaming;
 use anyhow::{anyhow, bail, Context, Result};
 use std::path::Path;
 use tokio_util::sync::CancellationToken;
@@ -13,7 +13,12 @@ pub const MIN_SOURCE_MS: u64 = 20_000;
 pub const MAX_SOURCE_MS: u64 = 4 * 3600 * 1000;
 
 /// Inspect and validate the uploaded source. Errors are user-actionable.
-pub async fn probe(cfg: &Config, src: &Path, original_filename: &str) -> Result<SourceInfo> {
+pub async fn probe(
+    cfg: &Config,
+    src: &Path,
+    original_filename: &str,
+    cancel: &CancellationToken,
+) -> Result<SourceInfo> {
     let args: Vec<String> = vec![
         "-v".into(),
         "error".into(),
@@ -23,9 +28,15 @@ pub async fn probe(cfg: &Config, src: &Path, original_filename: &str) -> Result<
         "-show_streams".into(),
         src.to_string_lossy().into_owned(),
     ];
-    let out = run_capture(&cfg.ffprobe, &args)
+    let out = crate::util::run_capture_cancellable(&cfg.ffprobe, &args, cancel)
         .await
-        .map_err(|e| anyhow!("This file could not be read as a video. {}", e))?;
+        .map_err(|e| {
+            if e.to_string().contains("cancelled") {
+                e
+            } else {
+                anyhow!("This file could not be read as a video. {}", e)
+            }
+        })?;
     let v: serde_json::Value =
         serde_json::from_str(&out).context("ffprobe returned unparseable output")?;
 

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -8,33 +8,49 @@
 use crate::captions::{accent_bgr_for, build_ass, CaptionInput, CaptionStyle};
 use crate::domain::*;
 use crate::state::{AppState, ProjectHandle};
-use crate::util::slugify;
+use crate::util::{promote_atomic, slugify, unique_temp_path};
 use crate::validate::interval_confidence;
 use anyhow::Result;
 use chrono::Utc;
+use futures::FutureExt;
 use serde_json::json;
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 const LOW_CONFIDENCE: f32 = 0.66;
+const CANCEL_ACK_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Start (or resume) processing for a project. Returns an error string if a
 /// run is already active.
-pub fn start(state: AppState, id: String) -> Result<(), String> {
+pub async fn start(state: AppState, id: String) -> Result<(), String> {
     let handle = state.handle(&id);
-    if handle.running.swap(true, Ordering::SeqCst) {
-        return Err("Processing is already running for this project.".into());
-    }
-    let token = CancellationToken::new();
-    *handle.cancel.lock().unwrap() = token.clone();
+    let _operation = handle.operation.lock().await;
+    start_locked(state, id, handle.clone())
+}
+
+fn start_locked(state: AppState, id: String, handle: Arc<ProjectHandle>) -> Result<(), String> {
+    let lease = handle
+        .try_start()
+        .ok_or_else(|| "Processing is already running for this project.".to_string())?;
+    let token = lease.token;
+    let generation = lease.generation;
     handle.clear_live();
 
     tokio::spawn(async move {
         let hid = id.clone();
-        if let Err(e) = run(state.clone(), id, handle.clone(), token).await {
+        let result = AssertUnwindSafe(run(state.clone(), id, handle.clone(), token))
+            .catch_unwind()
+            .await;
+        let failure = match result {
+            Ok(Ok(())) => None,
+            Ok(Err(error)) => Some(error),
+            Err(_) => Some(anyhow::anyhow!("pipeline task panicked")),
+        };
+        if let Some(e) = failure {
             tracing::error!(project = %hid, "pipeline task error: {e:#}");
             let message = format!("Processing failed unexpectedly. {e}");
             if let Ok(mut project) = state.store.load_project(&hid).await {
@@ -51,46 +67,91 @@ pub fn start(state: AppState, id: String) -> Result<(), String> {
             }
             handle.emit(json!({"type": "done", "status": "failed"}));
         }
-        handle.running.store(false, Ordering::SeqCst);
+        handle.finish(generation);
         handle.clear_live();
     });
     Ok(())
 }
 
-pub fn cancel(state: &AppState, id: &str) -> bool {
+pub enum CancelOutcome {
+    Cancelled,
+    Status(JobState),
+}
+
+async fn wait_for_cancel_ack(
+    done: &mut watch::Receiver<bool>,
+    timeout: Duration,
+) -> Result<(), String> {
+    let wait = async {
+        while !*done.borrow() {
+            done.changed().await.map_err(|_| {
+                "Processing run ended before cancellation was acknowledged.".to_string()
+            })?;
+        }
+        Ok::<(), String>(())
+    };
+    tokio::time::timeout(timeout, wait)
+        .await
+        .map_err(|_| {
+            format!(
+                "Cancellation did not reach a terminal state within {} ms; no cancellation acknowledgement was issued.",
+                timeout.as_millis()
+            )
+        })??;
+    Ok(())
+}
+
+pub async fn cancel(state: &AppState, id: &str) -> Result<CancelOutcome, String> {
     let handle = state.handle(id);
-    let running = handle.is_running();
-    handle.cancel.lock().unwrap().cancel();
-    running
+    let mut done = {
+        let _operation = handle.operation.lock().await;
+        handle.request_cancel()
+    };
+    if let Some(done) = done.as_mut() {
+        wait_for_cancel_ack(done, CANCEL_ACK_TIMEOUT).await?;
+    }
+
+    let project = state
+        .store
+        .load_project(id)
+        .await
+        .map_err(|e| e.to_string())?;
+    if project.status == JobState::Cancelled {
+        Ok(CancelOutcome::Cancelled)
+    } else {
+        Ok(CancelOutcome::Status(project.status))
+    }
 }
 
 /// Reset failure markers so a new run resumes from persisted artifacts, then start.
 pub async fn retry(state: AppState, id: String) -> Result<(), String> {
     let handle = state.handle(&id);
+    let _operation = handle.operation.lock().await;
     if handle.is_running() {
-        return Err("Processing is already running.".into());
+        return Err("Processing is already running for this project.".into());
     }
+    state
+        .store
+        .cleanup_partial_files(&id)
+        .await
+        .map_err(|e| e.to_string())?;
+
     let mut p = state
         .store
         .load_project(&id)
         .await
         .map_err(|e| e.to_string())?;
     for s in &mut p.stages {
-        if s.error.is_some() {
+        if s.error.is_some() || s.detail.as_deref() == Some("Cancelled") {
             s.error = None;
             s.started_at = None;
             s.completed_at = None;
             s.progress = None;
+            s.detail = None;
         }
     }
     p.error = None;
     p.status = JobState::Created;
-    state
-        .store
-        .save_project(&p)
-        .await
-        .map_err(|e| e.to_string())?;
-
     if let Ok(mut manifest) = state.store.load_manifest(&id).await {
         let mut changed = false;
         for c in &mut manifest.clips {
@@ -104,7 +165,12 @@ pub async fn retry(state: AppState, id: String) -> Result<(), String> {
             state.store.save_manifest(&id, &manifest).await.ok();
         }
     }
-    start(state, id)
+    state
+        .store
+        .save_project(&p)
+        .await
+        .map_err(|e| e.to_string())?;
+    start_locked(state, id, handle.clone())
 }
 
 // ---------------------------------------------------------------------------
@@ -176,14 +242,24 @@ impl Ctx {
             .emit(json!({"type": "done", "status": "failed"}));
     }
 
-    async fn mark_cancelled(&self, p: &mut Project, stage: &str) {
+    async fn mark_cancelled(&self, p: &mut Project, stage: &str) -> Result<()> {
         p.status = JobState::Cancelled;
+        p.error = None;
         let rec = p.stage_mut(stage);
+        let now = Utc::now();
+        if rec.started_at.is_none() {
+            rec.started_at = Some(now);
+        }
+        rec.completed_at = Some(now);
+        rec.progress = Some(rec.progress.unwrap_or(0.0));
         rec.detail = Some("Cancelled".into());
-        self.state.store.save_project(p).await.ok();
+        rec.error = None;
+        self.state.store.save_project(p).await?;
         self.handle.clear_live();
+        self.emit_stage(p, stage, "cancelled");
         self.handle
             .emit(json!({"type": "done", "status": "cancelled"}));
+        Ok(())
     }
 
     /// Throttled live-progress reporter for a stage.
@@ -230,7 +306,7 @@ async fn run(
     macro_rules! stage {
         ($name:literal, $body:expr) => {{
             if ctx.cancel.is_cancelled() {
-                ctx.mark_cancelled(&mut p, $name).await;
+                ctx.mark_cancelled(&mut p, $name).await?;
                 return Ok(());
             }
             ctx.begin(&mut p, $name).await?;
@@ -242,7 +318,7 @@ async fn run(
                 Err(e) => {
                     let e: anyhow::Error = e;
                     if is_cancelled(&e, &ctx.cancel) {
-                        ctx.mark_cancelled(&mut p, $name).await;
+                        ctx.mark_cancelled(&mut p, $name).await?;
                     } else {
                         ctx.fail(&mut p, $name, e.to_string()).await;
                     }
@@ -263,7 +339,7 @@ async fn run(
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "source.mp4".into());
         stage!("inspecting", {
-            match crate::media::probe(cfg, &src, &original).await {
+            match crate::media::probe(cfg, &src, &original, &ctx.cancel).await {
                 Ok(info) => {
                     let detail = format!(
                         "{}×{} · {} · {}/{}",
@@ -290,24 +366,39 @@ async fn run(
             .await?;
     } else {
         let wav = store.audio_path(&id);
-        if wav.is_file() {
-            ctx.skip(&mut p, "extracting_audio", "Audio already extracted")
-                .await?;
-        } else {
-            let mut prog = ctx.progress_fn("extracting_audio");
-            stage!("extracting_audio", {
+        // A previous run may have been killed after FFmpeg created the final
+        // path. Always rebuild from a unique sibling and promote only after
+        // FFmpeg has exited successfully.
+        tokio::fs::remove_file(&wav).await.ok();
+        let wav_temp = unique_temp_path(&wav);
+        let mut prog = ctx.progress_fn("extracting_audio");
+        stage!("extracting_audio", {
+            let result = async {
                 crate::media::extract_audio(
                     cfg,
                     &src,
-                    &wav,
+                    &wav_temp,
                     source.duration_ms,
                     &ctx.cancel,
                     |pct| prog(pct, None),
                 )
-                .await
-                .map(|_| "16 kHz mono audio ready".to_string())
-            });
-        }
+                .await?;
+                let metadata = tokio::fs::metadata(&wav_temp).await?;
+                if !metadata.is_file() || metadata.len() == 0 {
+                    return Err(anyhow::anyhow!("Audio extraction produced an empty file."));
+                }
+                if ctx.cancel.is_cancelled() {
+                    return Err(anyhow::anyhow!("cancelled"));
+                }
+                promote_atomic(&wav_temp, &wav).await?;
+                Ok::<String, anyhow::Error>("16 kHz mono audio ready".to_string())
+            }
+            .await;
+            if result.is_err() {
+                tokio::fs::remove_file(&wav_temp).await.ok();
+            }
+            result
+        });
     }
 
     // ---- 3. Transcribe ----------------------------------------------------
@@ -349,7 +440,12 @@ async fn run(
     } else {
         let settings = state.settings.read().unwrap().clone();
         stage!("selecting_candidates", {
-            match crate::select::propose(&settings, &transcript, &source).await {
+            let proposed = tokio::select! {
+                biased;
+                _ = ctx.cancel.cancelled() => Err(anyhow::anyhow!("cancelled")),
+                result = crate::select::propose(&settings, &transcript, &source) => result,
+            };
+            match proposed {
                 Ok(outcome) => {
                     store.save_raw_candidates(&id, &outcome.candidates).await?;
                     p.selector = Some(outcome.selector.clone());
@@ -381,6 +477,10 @@ async fn run(
 
     // No passing moments is a valid, honest outcome (PRD §6.2, §8.3).
     if report.accepted.is_empty() {
+        if ctx.cancel.is_cancelled() {
+            ctx.mark_cancelled(&mut p, "validating_candidates").await?;
+            return Ok(());
+        }
         ctx.skip(
             &mut p,
             "analyzing_layout",
@@ -487,15 +587,30 @@ async fn run(
 
     // ---- 7. Render (sequential, incremental, per-clip isolation) ------------
     let mut manifest = store.load_manifest(&id).await?;
-    ctx.begin(&mut p, "rendering").await?;
-    if !crate::util::ffmpeg_has_ass(&cfg.ffmpeg).await {
-        ctx.fail(
-            &mut p,
-            "rendering",
-            "This FFmpeg build cannot burn captions because the ASS filter is missing. On macOS, install `ffmpeg-full` with Homebrew and restart.".into(),
-        )
-        .await;
+    if ctx.cancel.is_cancelled() {
+        ctx.mark_cancelled(&mut p, "rendering").await?;
         return Ok(());
+    }
+    ctx.begin(&mut p, "rendering").await?;
+    match crate::util::ffmpeg_has_ass_cancellable(&cfg.ffmpeg, &ctx.cancel).await {
+        Ok(true) => {}
+        Ok(false) => {
+            ctx.fail(
+                &mut p,
+                "rendering",
+                "This FFmpeg build cannot burn captions because the ASS filter is missing. On macOS, install `ffmpeg-full` with Homebrew and restart.".into(),
+            )
+            .await;
+            return Ok(());
+        }
+        Err(e) if is_cancelled(&e, &ctx.cancel) => {
+            ctx.mark_cancelled(&mut p, "rendering").await?;
+            return Ok(());
+        }
+        Err(e) => {
+            ctx.fail(&mut p, "rendering", e.to_string()).await;
+            return Ok(());
+        }
     }
     let caption_style =
         CaptionStyle::from_str(p.caption_style.as_deref().unwrap_or(&cfg.caption_style));
@@ -513,12 +628,14 @@ async fn run(
 
     for i in 0..manifest.clips.len() {
         if ctx.cancel.is_cancelled() {
-            ctx.mark_cancelled(&mut p, "rendering").await;
+            ctx.mark_cancelled(&mut p, "rendering").await?;
             return Ok(());
         }
         let clip = manifest.clips[i].clone();
         let out_path = store.clips_dir(&id).join(&clip.filename);
-        if clip.status == ClipStatus::Ready && out_path.is_file() {
+        if clip.status == ClipStatus::Ready
+            && store.final_is_ready(&id, &clip.id, &clip.filename).await?
+        {
             continue;
         }
 
@@ -531,13 +648,19 @@ async fn run(
         let done_label = format!("Rendering clip {} of {}", i + 1, total);
         let caption_label = format!("Burning captions for clip {} of {}", i + 1, total);
         let base_path = store.base_clip_path(&id, &clip.id);
-        let ass_path: PathBuf = store.clips_dir(&id).join(format!("{}.ass", clip.id));
+        let ass_path: PathBuf =
+            unique_temp_path(&store.clips_dir(&id).join(format!("{}.ass", clip.id)));
+        let base_temp = unique_temp_path(&base_path);
+        let out_temp = unique_temp_path(&out_path);
+        let base_ready = store.base_is_ready(&id, &clip.id).await?;
 
         let render_result: anyhow::Result<()> = async {
             // Pass 1 — framed, uncaptioned base. Kept on disk so captions can
             // be restyled later without re-doing the expensive framing work
             // (and reused as-is when retrying a failed caption burn).
-            if !base_path.is_file() {
+            if !base_ready {
+                tokio::fs::remove_file(&base_path).await.ok();
+                store.clear_base_ready(&id, &clip.id).await;
                 crate::render::render_base_clip(
                     cfg,
                     &src,
@@ -545,11 +668,16 @@ async fn run(
                     &clip.layout,
                     clip.start_ms,
                     clip.end_ms,
-                    &base_path,
+                    &base_temp,
                     &ctx.cancel,
                     |pct| prog(pct * 0.85, Some(done_label.clone())),
                 )
                 .await?;
+                if ctx.cancel.is_cancelled() {
+                    return Err(anyhow::anyhow!("cancelled"));
+                }
+                promote_atomic(&base_temp, &base_path).await?;
+                store.mark_base_ready(&id, &clip.id).await?;
             }
             // Pass 2 — word-accurate captions burned onto the base.
             let words =
@@ -566,20 +694,32 @@ async fn run(
                 caption_style,
             );
             tokio::fs::write(&ass_path, &ass).await?;
+            if ctx.cancel.is_cancelled() {
+                return Err(anyhow::anyhow!("cancelled"));
+            }
             let burn = crate::render::burn_captions(
                 cfg,
                 &base_path,
                 &ass_path,
-                &out_path,
+                &out_temp,
                 clip.end_ms.saturating_sub(clip.start_ms),
                 &ctx.cancel,
                 |pct| prog(0.85 + pct * 0.15, Some(caption_label.clone())),
             )
             .await;
-            tokio::fs::remove_file(&ass_path).await.ok();
-            burn
+            burn?;
+            if ctx.cancel.is_cancelled() {
+                return Err(anyhow::anyhow!("cancelled"));
+            }
+            promote_atomic(&out_temp, &out_path).await?;
+            store.mark_final_ready(&id, &clip.id).await?;
+            Ok(())
         }
         .await;
+
+        tokio::fs::remove_file(&base_temp).await.ok();
+        tokio::fs::remove_file(&out_temp).await.ok();
+        tokio::fs::remove_file(&ass_path).await.ok();
 
         match render_result {
             Ok(()) => {
@@ -598,18 +738,33 @@ async fn run(
                 store.save_manifest(&id, &manifest).await?;
                 ctx.handle
                     .emit(json!({"type": "clip", "clip": manifest.clips[i]}));
+                if ctx.cancel.is_cancelled() {
+                    ctx.mark_cancelled(&mut p, "rendering").await?;
+                    return Ok(());
+                }
             }
             Err(e) if is_cancelled(&e, &ctx.cancel) => {
+                tokio::fs::remove_file(&out_path).await.ok();
+                store.clear_final_ready(&id, &clip.id).await;
+                if !base_ready {
+                    tokio::fs::remove_file(&base_path).await.ok();
+                    store.clear_base_ready(&id, &clip.id).await;
+                }
                 manifest.clips[i].status = ClipStatus::Pending;
                 store.save_manifest(&id, &manifest).await?;
-                ctx.mark_cancelled(&mut p, "rendering").await;
+                ctx.mark_cancelled(&mut p, "rendering").await?;
                 return Ok(());
             }
             Err(e) => {
                 // A failed render must not discard successful outputs (PRD §12).
                 // Drop this clip's base so retry rebuilds it from scratch — a
                 // truncated base from a crash would poison every re-burn.
-                tokio::fs::remove_file(&base_path).await.ok();
+                if !base_ready {
+                    tokio::fs::remove_file(&base_path).await.ok();
+                    store.clear_base_ready(&id, &clip.id).await;
+                }
+                tokio::fs::remove_file(&out_path).await.ok();
+                store.clear_final_ready(&id, &clip.id).await;
                 manifest.clips[i].status = ClipStatus::Failed;
                 manifest.clips[i].error = Some(e.to_string());
                 store.save_manifest(&id, &manifest).await?;
@@ -629,6 +784,11 @@ async fn run(
         .iter()
         .filter(|c| c.status == ClipStatus::Failed)
         .count();
+
+    if ctx.cancel.is_cancelled() {
+        ctx.mark_cancelled(&mut p, "rendering").await?;
+        return Ok(());
+    }
 
     if ready > 0 {
         ctx.complete(
@@ -657,4 +817,50 @@ async fn run(
         .await;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+
+    #[tokio::test]
+    async fn cancellation_persists_terminal_stage_metadata() {
+        let tmp = std::env::temp_dir().join(format!("cf-cancel-{}", crate::util::short_id()));
+        let mut cfg = Config::resolve();
+        cfg.data_dir = tmp.join("data");
+        cfg.output_root = tmp.join("output");
+        let state = AppState::new(cfg);
+        let id = "cancel-test".to_string();
+
+        state.store.create_dirs(&id).await.unwrap();
+        state
+            .store
+            .save_project(&Project::new(id.clone(), state.store.source_path(&id)))
+            .await
+            .unwrap();
+
+        let token = CancellationToken::new();
+        token.cancel();
+        run(state.clone(), id.clone(), state.handle(&id), token)
+            .await
+            .unwrap();
+
+        let mut project = state.store.load_project(&id).await.unwrap();
+        assert_eq!(project.status, JobState::Cancelled);
+        let stage = project.stage_mut("inspecting");
+        assert!(stage.started_at.is_some());
+        assert!(stage.completed_at.is_some());
+        assert_eq!(stage.detail.as_deref(), Some("Cancelled"));
+
+        tokio::fs::remove_dir_all(tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn cancellation_ack_timeout_returns_an_error_instead_of_hanging() {
+        let (_sender, mut done) = watch::channel(false);
+        let result = wait_for_cancel_ack(&mut done, Duration::from_millis(10)).await;
+        let message = result.unwrap_err();
+        assert!(message.contains("no cancellation acknowledgement"));
+    }
 }

--- a/src/select/anthropic.rs
+++ b/src/select/anthropic.rs
@@ -3,11 +3,19 @@
 use super::openai::map_error;
 use anyhow::{anyhow, Result};
 use serde_json::json;
+use std::time::Duration;
 
 const VERSION: &str = "2023-06-01";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn client() -> Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()?)
+}
 
 pub async fn complete(key: &str, model: &str, system: &str, user: &str) -> Result<String> {
-    let client = reqwest::Client::new();
+    let client = client()?;
     let body = json!({
         "model": model,
         "max_tokens": 4000,
@@ -38,7 +46,7 @@ pub async fn complete(key: &str, model: &str, system: &str, user: &str) -> Resul
 }
 
 pub async fn test(key: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = client()?;
     let resp = client
         .get("https://api.anthropic.com/v1/models")
         .header("x-api-key", key)

--- a/src/select/heuristic.rs
+++ b/src/select/heuristic.rs
@@ -98,6 +98,31 @@ const PRONOUN_OPENERS: &[&str] = &[
 
 const FILLER_WORDS: &[&str] = &["um", "uh", "like", "you know", "kind of", "sort of"];
 
+// These are production/editorial blockers, not quality signals. A local
+// selector should never turn routine show housekeeping or an ad read into a
+// clip merely because the window happens to be long enough.
+const HOUSEKEEPING_OR_SPONSOR_CUES: &[&str] = &[
+    "welcome back to the show",
+    "today we are going to talk about",
+    "before we begin",
+    "subscribe and leave a review",
+    "we will be right back",
+    "we'll be right back",
+    "thanks for listening",
+    "now let us get into the conversation",
+    "now let's get into the conversation",
+    "this episode is brought to you by",
+    "brought to you by",
+    "sponsored by",
+    "use the code",
+    "discount at checkout",
+    "in the episode notes",
+    "in the show notes",
+    "sponsor link",
+    "thanks to our sponsor",
+    "support for the show",
+];
+
 const MIN_MS: u64 = 20_000;
 const MAX_MS: u64 = 90_000;
 
@@ -176,9 +201,11 @@ pub fn propose(t: &Transcript, source_duration_ms: u64, proposal_count: usize) -
         let reference = REFERENCE_CUES.iter().any(|c| window_lower.contains(c));
         let has_number = window_text.chars().any(|c| c.is_ascii_digit());
         let word_count = window_text.split_whitespace().count().max(1);
+        let normalized_window = normalized_claim(&window_lower);
+        let normalized_words: Vec<&str> = normalized_window.split_whitespace().collect();
         let filler_count = FILLER_WORDS
             .iter()
-            .map(|f| window_lower.matches(f).count())
+            .map(|f| count_phrase_occurrences(&normalized_words, f))
             .sum::<usize>();
         let filler_rate = filler_count as f32 / word_count as f32;
         let question_open = opener.text.contains('?')
@@ -186,6 +213,21 @@ pub fn propose(t: &Transcript, source_duration_ms: u64, proposal_count: usize) -
         let repeated_claim = has_repeated_claim(window);
         let exchange = has_reaction_exchange(window);
         let absolute_claim = contains_absolute_claim(&window_lower);
+
+        // Keep routine housekeeping, sponsor reads, and filler-heavy windows
+        // out of the candidate set before ranking can reward their length.
+        // The signal gate below remains deliberately narrow so a specific,
+        // standalone thought with no magic phrase can still be proposed.
+        if has_housekeeping_or_sponsor_cue(&window_lower)
+            || is_filler_dominated(filler_count, filler_rate)
+        {
+            continue;
+        }
+        let has_editorial_signal =
+            hook || contrast || payoff_cue || repeated_claim || exchange || absolute_claim;
+        if !has_editorial_signal {
+            continue;
+        }
 
         let self_contained: u8 = match (pronoun_open, reference) {
             (false, false) => {
@@ -334,6 +376,27 @@ fn is_vague_opener(text: &str) -> bool {
             || text.starts_with("it "))
 }
 
+fn has_housekeeping_or_sponsor_cue(text: &str) -> bool {
+    HOUSEKEEPING_OR_SPONSOR_CUES
+        .iter()
+        .any(|cue| text.contains(cue))
+}
+
+fn is_filler_dominated(filler_count: usize, filler_rate: f32) -> bool {
+    filler_count >= 5 && filler_rate >= 0.08
+}
+
+fn count_phrase_occurrences(words: &[&str], phrase: &str) -> usize {
+    let phrase_words: Vec<&str> = phrase.split_whitespace().collect();
+    if phrase_words.is_empty() || phrase_words.len() > words.len() {
+        return 0;
+    }
+    words
+        .windows(phrase_words.len())
+        .filter(|window| *window == phrase_words.as_slice())
+        .count()
+}
+
 fn normalized_claim(text: &str) -> String {
     text.to_lowercase()
         .chars()
@@ -416,9 +479,13 @@ fn make_headline(opener: &Sentence) -> String {
         }
     }
     let mut headline = text.trim_end_matches(['.', ',']).to_string();
-    if headline.len() > 90 {
-        let cut = headline[..90].rfind(' ').unwrap_or(87);
-        headline = format!("{}…", headline[..cut].trim_end());
+    if headline.chars().count() > 90 {
+        let prefix: String = headline.chars().take(90).collect();
+        let cut = prefix
+            .rfind(' ')
+            .or_else(|| prefix.char_indices().nth(87).map(|(i, _)| i))
+            .unwrap_or(prefix.len());
+        headline = format!("{}…", prefix[..cut].trim_end());
     }
     // Sentence case.
     let mut chars = headline.chars();
@@ -571,5 +638,92 @@ mod tests {
         assert!(is_vague_opener("how would that work?"));
         assert!(is_vague_opener("are those things possible?"));
         assert!(!is_vague_opener("can everyone be rich?"));
+    }
+
+    #[test]
+    fn accented_headline_truncation_is_utf8_safe() {
+        let text = format!("What {}", "é ".repeat(120));
+        let t = Transcript {
+            language: "en".into(),
+            words: vec![],
+            sentences: vec![Sentence {
+                text,
+                start_ms: 0,
+                end_ms: 40_000,
+                word_start: 0,
+                word_end: 0,
+            }],
+            avg_confidence: 0.92,
+        };
+
+        let cands = propose(&t, 60_000, 1);
+        assert_eq!(cands.len(), 1);
+        assert!(cands[0].headline.ends_with('…'));
+        assert!(cands[0].headline.chars().count() <= 91);
+    }
+
+    #[test]
+    fn filler_count_uses_whole_words_and_phrases() {
+        let words = ["number", "summary", "unlikely", "like", "you", "know"];
+        assert_eq!(count_phrase_occurrences(&words, "um"), 0);
+        assert_eq!(count_phrase_occurrences(&words, "like"), 1);
+        assert_eq!(count_phrase_occurrences(&words, "you know"), 1);
+    }
+
+    #[test]
+    fn numbers_alone_do_not_turn_housekeeping_into_a_candidate() {
+        let t = transcript_from(&[
+            ("Episode 42 covers our 3 schedule changes.", 0),
+            (
+                "The first item starts at 9 and the second starts at 10.",
+                500,
+            ),
+            ("We also have 2 reminders for next week's recording.", 500),
+            ("That is the full schedule for episode 42.", 500),
+        ]);
+        let duration = t.words.last().unwrap().end_ms + 500;
+        assert!(propose(&t, duration, 3).is_empty());
+    }
+
+    #[derive(serde::Deserialize)]
+    struct EditorialFixture {
+        name: String,
+        expected: String,
+        sentences: Vec<String>,
+    }
+
+    #[test]
+    fn synthetic_editorial_fixtures_match_selector_expectations() {
+        let fixtures: Vec<EditorialFixture> =
+            serde_json::from_str(include_str!("../../evals/fixtures/editorial_cases.json"))
+                .unwrap();
+
+        for fixture in fixtures {
+            let script: Vec<(&str, u64)> = fixture
+                .sentences
+                .iter()
+                .enumerate()
+                .map(|(idx, sentence)| (sentence.as_str(), if idx == 0 { 0 } else { 400 }))
+                .collect();
+            let t = transcript_from(&script);
+            let duration = t.words.last().map(|w| w.end_ms + 500).unwrap_or(60_000);
+            let candidates = propose(&t, duration, 3);
+            let observed = if candidates.is_empty() {
+                "reject"
+            } else {
+                "accept"
+            };
+            println!(
+                "{}: {} candidate(s) -> {}",
+                fixture.name,
+                candidates.len(),
+                observed
+            );
+            assert_eq!(
+                observed, fixture.expected,
+                "fixture {} produced the wrong selector outcome",
+                fixture.name
+            );
+        }
     }
 }

--- a/src/select/openai.rs
+++ b/src/select/openai.rs
@@ -3,9 +3,18 @@
 
 use anyhow::{anyhow, Result};
 use serde_json::json;
+use std::time::Duration;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn client() -> Result<reqwest::Client> {
+    Ok(reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()?)
+}
 
 pub async fn complete(key: &str, model: &str, system: &str, user: &str) -> Result<String> {
-    let client = reqwest::Client::new();
+    let client = client()?;
     let body = json!({
         "model": model,
         "temperature": 0.3,
@@ -37,7 +46,7 @@ pub async fn complete(key: &str, model: &str, system: &str, user: &str) -> Resul
 }
 
 pub async fn test(key: &str) -> Result<()> {
-    let client = reqwest::Client::new();
+    let client = client()?;
     let resp = client
         .get("https://api.openai.com/v1/models")
         .bearer_auth(key)

--- a/src/state.rs
+++ b/src/state.rs
@@ -6,9 +6,8 @@ use crate::settings::AiSettings;
 use crate::store::Store;
 use serde::Serialize;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, RwLock};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, watch, Mutex as AsyncMutex};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Clone, Serialize, Debug)]
@@ -20,11 +19,27 @@ pub struct LiveStage {
 
 pub struct ProjectHandle {
     pub events: broadcast::Sender<String>,
-    pub cancel: Mutex<CancellationToken>,
-    pub running: AtomicBool,
+    pub operation: AsyncMutex<()>,
+    run: Mutex<RunState>,
     /// In-memory progress for the currently executing stage. Durable state
     /// transitions live in project.json; this fills the gaps between them.
     pub live: Mutex<Option<LiveStage>>,
+}
+
+struct RunState {
+    next_generation: u64,
+    active: Option<ActiveRun>,
+}
+
+struct ActiveRun {
+    generation: u64,
+    token: CancellationToken,
+    done: watch::Sender<bool>,
+}
+
+pub struct RunLease {
+    pub token: CancellationToken,
+    pub(crate) generation: u64,
 }
 
 impl ProjectHandle {
@@ -32,8 +47,11 @@ impl ProjectHandle {
         let (tx, _) = broadcast::channel(512);
         Arc::new(ProjectHandle {
             events: tx,
-            cancel: Mutex::new(CancellationToken::new()),
-            running: AtomicBool::new(false),
+            operation: AsyncMutex::new(()),
+            run: Mutex::new(RunState {
+                next_generation: 0,
+                active: None,
+            }),
             live: Mutex::new(None),
         })
     }
@@ -55,7 +73,45 @@ impl ProjectHandle {
     }
 
     pub fn is_running(&self) -> bool {
-        self.running.load(std::sync::atomic::Ordering::SeqCst)
+        self.run.lock().unwrap().active.is_some()
+    }
+
+    pub fn try_start(&self) -> Option<RunLease> {
+        let mut run = self.run.lock().unwrap();
+        if run.active.is_some() {
+            return None;
+        }
+        run.next_generation = run.next_generation.saturating_add(1);
+        let token = CancellationToken::new();
+        let (done, _) = watch::channel(false);
+        let generation = run.next_generation;
+        run.active = Some(ActiveRun {
+            generation,
+            token: token.clone(),
+            done,
+        });
+        Some(RunLease { token, generation })
+    }
+
+    pub fn request_cancel(&self) -> Option<watch::Receiver<bool>> {
+        let run = self.run.lock().unwrap();
+        let active = run.active.as_ref()?;
+        let done = active.done.subscribe();
+        active.token.cancel();
+        Some(done)
+    }
+
+    pub fn finish(&self, generation: u64) {
+        let done = {
+            let mut run = self.run.lock().unwrap();
+            if run.active.as_ref().map(|active| active.generation) != Some(generation) {
+                return;
+            }
+            run.active.take().map(|active| active.done)
+        };
+        if let Some(done) = done {
+            let _ = done.send(true);
+        }
     }
 }
 
@@ -97,5 +153,40 @@ impl AppState {
 
     pub fn end_restyle(&self, key: &str) {
         self.restyling.lock().unwrap().remove(key);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cancel_without_an_active_run_does_not_poison_the_next_run() {
+        let handle = ProjectHandle::new();
+
+        assert!(handle.request_cancel().is_none());
+
+        let lease = handle.try_start().expect("run should start");
+        assert!(!lease.token.is_cancelled());
+        handle.finish(lease.generation);
+    }
+
+    #[test]
+    fn duplicate_cancel_is_idempotent_and_a_stale_finish_cannot_end_new_run() {
+        let handle = ProjectHandle::new();
+        let first = handle.try_start().expect("first run should start");
+        let first_done = handle.request_cancel().expect("first run is cancellable");
+        let second_done = handle.request_cancel().expect("duplicate cancel is safe");
+        assert!(first.token.is_cancelled());
+
+        handle.finish(first.generation);
+        assert!(*first_done.borrow());
+        assert!(*second_done.borrow());
+
+        let second = handle.try_start().expect("next run should start");
+        handle.finish(first.generation);
+        assert!(handle.is_running(), "stale completion ended the new run");
+        handle.finish(second.generation);
+        assert!(!handle.is_running());
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -14,8 +14,9 @@
 //! ```
 
 use crate::domain::*;
-use crate::util::atomic_write_json;
+use crate::util::{atomic_write_bytes, atomic_write_json};
 use anyhow::{Context, Result};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 #[derive(Clone)]
@@ -65,6 +66,12 @@ impl Store {
     pub fn base_clip_path(&self, id: &str, clip_id: &str) -> PathBuf {
         self.base_dir(id).join(format!("{clip_id}.mp4"))
     }
+    pub fn base_ready_marker(&self, id: &str, clip_id: &str) -> PathBuf {
+        self.base_dir(id).join(format!("{clip_id}.ready"))
+    }
+    pub fn final_ready_marker(&self, id: &str, clip_id: &str) -> PathBuf {
+        self.clips_dir(id).join(format!("{clip_id}.ready"))
+    }
     pub fn frames_dir(&self, id: &str) -> PathBuf {
         self.project_dir(id).join("frames")
     }
@@ -75,6 +82,149 @@ impl Store {
 
     pub async fn create_dirs(&self, id: &str) -> Result<()> {
         tokio::fs::create_dir_all(self.base_dir(id)).await?;
+        Ok(())
+    }
+
+    /// A base clip is reusable only when its completed media and promotion
+    /// marker both exist. This keeps old direct-to-final partials out of retry.
+    pub async fn base_is_ready(&self, id: &str, clip_id: &str) -> Result<bool> {
+        let media = tokio::fs::metadata(self.base_clip_path(id, clip_id)).await;
+        let marker = tokio::fs::metadata(self.base_ready_marker(id, clip_id)).await;
+        Ok(media.map(|m| m.is_file() && m.len() > 0).unwrap_or(false)
+            && marker.map(|m| m.is_file() && m.len() > 0).unwrap_or(false))
+    }
+
+    pub async fn mark_base_ready(&self, id: &str, clip_id: &str) -> Result<()> {
+        atomic_write_bytes(&self.base_ready_marker(id, clip_id), b"ready\n").await
+    }
+
+    pub async fn clear_base_ready(&self, id: &str, clip_id: &str) {
+        tokio::fs::remove_file(self.base_ready_marker(id, clip_id))
+            .await
+            .ok();
+    }
+
+    pub async fn final_is_ready(&self, id: &str, clip_id: &str, filename: &str) -> Result<bool> {
+        let media = tokio::fs::metadata(self.clips_dir(id).join(filename)).await;
+        let marker = tokio::fs::metadata(self.final_ready_marker(id, clip_id)).await;
+        Ok(media.map(|m| m.is_file() && m.len() > 0).unwrap_or(false)
+            && marker.map(|m| m.is_file() && m.len() > 0).unwrap_or(false))
+    }
+
+    pub async fn mark_final_ready(&self, id: &str, clip_id: &str) -> Result<()> {
+        atomic_write_bytes(&self.final_ready_marker(id, clip_id), b"ready\n").await
+    }
+
+    pub async fn clear_final_ready(&self, id: &str, clip_id: &str) {
+        tokio::fs::remove_file(self.final_ready_marker(id, clip_id))
+            .await
+            .ok();
+    }
+
+    /// Remove artifacts that are not proven complete before a retry. Completed
+    /// final clips and marked base clips remain available for incremental retry.
+    pub async fn cleanup_partial_files(&self, id: &str) -> Result<()> {
+        let project_dir = self.project_dir(id);
+        if !project_dir.is_dir() {
+            return Ok(());
+        }
+
+        let mut ready_names = HashSet::new();
+        let mut ready_ids = HashSet::new();
+        if let Ok(manifest) = self.load_manifest(id).await {
+            for clip in manifest.clips {
+                if clip.status != ClipStatus::Ready {
+                    continue;
+                }
+                let media = self.clips_dir(id).join(&clip.filename);
+                let legacy_media_is_complete = tokio::fs::metadata(&media)
+                    .await
+                    .map(|m| m.is_file() && m.len() > 0)
+                    .unwrap_or(false);
+                if legacy_media_is_complete && !self.final_ready_marker(id, &clip.id).is_file() {
+                    self.mark_final_ready(id, &clip.id).await?;
+                }
+                if self.final_is_ready(id, &clip.id, &clip.filename).await? {
+                    ready_names.insert(clip.filename);
+                    ready_ids.insert(clip.id);
+                }
+            }
+        }
+
+        let mut root = tokio::fs::read_dir(&project_dir).await?;
+        while let Some(entry) = root.next_entry().await? {
+            let path = entry.path();
+            let file_type = entry.file_type().await?;
+            if file_type.is_dir() {
+                if entry.file_name() == "frames" {
+                    tokio::fs::remove_dir_all(path).await.ok();
+                }
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if name == "audio.wav"
+                || name.contains(".part-")
+                || name.starts_with(".whisper-")
+                || name.starts_with("audio.whisper")
+            {
+                tokio::fs::remove_file(path).await.ok();
+            }
+        }
+
+        let clips_dir = self.clips_dir(id);
+        if clips_dir.is_dir() {
+            let mut clips = tokio::fs::read_dir(&clips_dir).await?;
+            while let Some(entry) = clips.next_entry().await? {
+                let path = entry.path();
+                if entry.file_type().await?.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if name.ends_with(".ass")
+                    || name.contains(".part-")
+                    || (name.ends_with(".mp4") && !ready_names.contains(&name))
+                {
+                    tokio::fs::remove_file(path).await.ok();
+                } else if let Some(clip_id) = name.strip_suffix(".ready") {
+                    if !ready_ids.contains(clip_id) {
+                        tokio::fs::remove_file(path).await.ok();
+                    }
+                }
+            }
+        }
+
+        let base_dir = self.base_dir(id);
+        if base_dir.is_dir() {
+            let mut bases = tokio::fs::read_dir(&base_dir).await?;
+            while let Some(entry) = bases.next_entry().await? {
+                let path = entry.path();
+                if entry.file_type().await?.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().into_owned();
+                if name.contains(".part-") {
+                    tokio::fs::remove_file(path).await.ok();
+                } else if let Some(clip_id) = name.strip_suffix(".mp4") {
+                    if ready_ids.contains(clip_id)
+                        && tokio::fs::metadata(&path)
+                            .await
+                            .map(|m| m.is_file() && m.len() > 0)
+                            .unwrap_or(false)
+                        && !self.base_ready_marker(id, clip_id).is_file()
+                    {
+                        self.mark_base_ready(id, clip_id).await?;
+                    }
+                    if !self.base_is_ready(id, clip_id).await? {
+                        tokio::fs::remove_file(&path).await.ok();
+                        self.clear_base_ready(id, clip_id).await;
+                    }
+                } else if let Some(clip_id) = name.strip_suffix(".ready") {
+                    if !self.base_clip_path(id, clip_id).is_file() {
+                        tokio::fs::remove_file(path).await.ok();
+                    }
+                }
+            }
+        }
         Ok(())
     }
 
@@ -181,6 +331,143 @@ mod tests {
         assert_eq!(loaded.clips.len(), 1);
         assert_eq!(loaded.clips[0].layout, LayoutPlan::BlurPad);
         assert_eq!(loaded.clips[0].status, ClipStatus::Ready);
+
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn retry_cleanup_removes_unproven_artifacts_but_keeps_completed_clips() {
+        let tmp = std::env::temp_dir().join(format!("cf-cleanup-{}", crate::util::short_id()));
+        let store = Store::new(&tmp);
+        let id = "cleanup01";
+        store.create_dirs(id).await.unwrap();
+
+        let ready = ClipRecord {
+            id: "ready1".into(),
+            rank: 1,
+            headline: "Ready".into(),
+            filename: "01-ready.mp4".into(),
+            start_ms: 0,
+            end_ms: 20_000,
+            duration_ms: 20_000,
+            selection_reason: "test".into(),
+            scores: Scores::default(),
+            layout: LayoutPlan::BlurPad,
+            status: ClipStatus::Ready,
+            error: None,
+            low_confidence: false,
+            caption_style: None,
+            accent_color: None,
+            caption_font: None,
+        };
+        store
+            .save_manifest(
+                id,
+                &RenderManifest {
+                    clips: vec![ready],
+                    output_dir: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        tokio::fs::write(store.audio_path(id), b"partial")
+            .await
+            .unwrap();
+        tokio::fs::write(store.project_dir(id).join(".whisper-old.json"), b"partial")
+            .await
+            .unwrap();
+        tokio::fs::write(store.project_dir(id).join("stale.part-old.mp4"), b"partial")
+            .await
+            .unwrap();
+        tokio::fs::write(store.clips_dir(id).join("01-ready.mp4"), b"complete")
+            .await
+            .unwrap();
+        store.mark_final_ready(id, "ready1").await.unwrap();
+        tokio::fs::write(store.clips_dir(id).join("02-stale.mp4"), b"partial")
+            .await
+            .unwrap();
+        tokio::fs::write(store.clips_dir(id).join("ready1.ass"), b"partial")
+            .await
+            .unwrap();
+        tokio::fs::write(store.base_clip_path(id, "ready1"), b"complete")
+            .await
+            .unwrap();
+        store.mark_base_ready(id, "ready1").await.unwrap();
+        tokio::fs::write(store.base_clip_path(id, "stale1"), b"partial")
+            .await
+            .unwrap();
+
+        store.cleanup_partial_files(id).await.unwrap();
+
+        assert!(store.clips_dir(id).join("01-ready.mp4").is_file());
+        assert!(store
+            .final_is_ready(id, "ready1", "01-ready.mp4")
+            .await
+            .unwrap());
+        assert!(store.base_is_ready(id, "ready1").await.unwrap());
+        assert!(!store.audio_path(id).is_file());
+        assert!(!store.project_dir(id).join(".whisper-old.json").is_file());
+        assert!(!store.clips_dir(id).join("02-stale.mp4").is_file());
+        assert!(!store.clips_dir(id).join("ready1.ass").is_file());
+        assert!(!store.base_clip_path(id, "stale1").is_file());
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn retry_cleanup_preserves_and_marks_legacy_ready_clip_and_base() {
+        let tmp =
+            std::env::temp_dir().join(format!("cf-legacy-cleanup-{}", crate::util::short_id()));
+        let store = Store::new(&tmp);
+        let id = "legacy-cleanup01";
+        store.create_dirs(id).await.unwrap();
+
+        store
+            .save_manifest(
+                id,
+                &RenderManifest {
+                    clips: vec![ClipRecord {
+                        id: "legacy-ready".into(),
+                        rank: 1,
+                        headline: "Legacy Ready".into(),
+                        filename: "01-legacy-ready.mp4".into(),
+                        start_ms: 0,
+                        end_ms: 20_000,
+                        duration_ms: 20_000,
+                        selection_reason: "test".into(),
+                        scores: Scores::default(),
+                        layout: LayoutPlan::BlurPad,
+                        status: ClipStatus::Ready,
+                        error: None,
+                        low_confidence: false,
+                        caption_style: None,
+                        accent_color: None,
+                        caption_font: None,
+                    }],
+                    output_dir: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let final_path = store.clips_dir(id).join("01-legacy-ready.mp4");
+        let base_path = store.base_clip_path(id, "legacy-ready");
+        tokio::fs::write(&final_path, b"legacy-final")
+            .await
+            .unwrap();
+        tokio::fs::write(&base_path, b"legacy-base").await.unwrap();
+        assert!(!store.final_ready_marker(id, "legacy-ready").exists());
+        assert!(!store.base_ready_marker(id, "legacy-ready").exists());
+
+        store.cleanup_partial_files(id).await.unwrap();
+
+        assert_eq!(tokio::fs::read(&final_path).await.unwrap(), b"legacy-final");
+        assert_eq!(tokio::fs::read(&base_path).await.unwrap(), b"legacy-base");
+        assert!(store
+            .final_is_ready(id, "legacy-ready", "01-legacy-ready.mp4")
+            .await
+            .unwrap());
+        assert!(store.base_is_ready(id, "legacy-ready").await.unwrap());
 
         tokio::fs::remove_dir_all(&tmp).await.ok();
     }

--- a/src/transcribe.rs
+++ b/src/transcribe.rs
@@ -30,7 +30,13 @@ where
         .as_ref()
         .ok_or_else(|| anyhow!("Transcription model missing. Download ggml-base.en.bin (~148MB) into <data-dir>/models or set CF_WHISPER_MODEL."))?;
 
-    let out_prefix = wav.with_extension("whisper");
+    // Never let whisper write directly to a retry-visible name. A cancelled
+    // process may leave a JSON prefix that looks parseable on the next run.
+    let out_prefix = wav.with_file_name(format!(".whisper-{}", crate::util::short_id()));
+    let json_candidates = [
+        out_prefix.with_extension("json"),
+        out_prefix.with_extension("whisper.json"),
+    ];
     let args: Vec<String> = vec![
         "-m".into(),
         model.to_string_lossy().into_owned(),
@@ -49,56 +55,67 @@ where
         "--print-progress".into(),
     ];
 
-    run_streaming(&bin.to_string_lossy(), &args, cancel, |_is_err, line| {
-        // whisper.cpp prints `whisper_print_progress_callback: progress = 35%`
-        if let Some(idx) = line.find("progress =") {
-            let tail = &line[idx + 10..];
-            if let Ok(pct) = tail.trim().trim_end_matches('%').parse::<f32>() {
-                on_progress((pct / 100.0).clamp(0.0, 1.0));
+    let result: Result<Transcript> = async {
+        run_streaming(&bin.to_string_lossy(), &args, cancel, |_is_err, line| {
+            // whisper.cpp prints `whisper_print_progress_callback: progress = 35%`
+            if let Some(idx) = line.find("progress =") {
+                let tail = &line[idx + 10..];
+                if let Ok(pct) = tail.trim().trim_end_matches('%').parse::<f32>() {
+                    on_progress((pct / 100.0).clamp(0.0, 1.0));
+                }
             }
-        }
-    })
-    .await
-    .map_err(|e| {
-        if e.to_string().contains("cancelled") {
-            e
-        } else {
-            anyhow!("Transcription failed. {}", e)
-        }
-    })?;
-
-    let json_path = out_prefix.with_extension("whisper.json");
-    // whisper.cpp appends `.json` to the output prefix.
-    let json_path = if json_path.is_file() {
-        json_path
-    } else {
-        Path::new(&format!("{}.json", out_prefix.to_string_lossy())).to_path_buf()
-    };
-    let bytes = tokio::fs::read(&json_path)
+        })
         .await
-        .with_context(|| format!("whisper output not found at {}", json_path.display()))?;
-    let parsed: serde_json::Value = serde_json::from_slice(&bytes)?;
-    tokio::fs::remove_file(&json_path).await.ok();
+        .map_err(|e| {
+            if e.to_string().contains("cancelled") {
+                e
+            } else {
+                anyhow!("Transcription failed. {}", e)
+            }
+        })?;
 
-    let words = parse_words(&parsed);
-    if words.is_empty() {
-        return Err(anyhow!(
-            "No speech was detected in this video. Clipping Factory needs clear spoken audio."
-        ));
+        // whisper.cpp appends `.json` to the output prefix. Keep a fallback
+        // for versions that insert `.whisper` before that suffix.
+        let json_path = json_candidates
+            .iter()
+            .find(|path| path.is_file())
+            .ok_or_else(|| {
+                anyhow!(
+                    "whisper output not found at {}",
+                    json_candidates[0].display()
+                )
+            })?;
+        let bytes = tokio::fs::read(json_path)
+            .await
+            .with_context(|| format!("reading whisper output at {}", json_path.display()))?;
+        let parsed: serde_json::Value = serde_json::from_slice(&bytes)?;
+
+        let words = parse_words(&parsed);
+        if words.is_empty() {
+            return Err(anyhow!(
+                "No speech was detected in this video. Clipping Factory needs clear spoken audio."
+            ));
+        }
+        let sentences = build_sentences(&words);
+        let avg_confidence = words.iter().map(|w| w.p).sum::<f32>() / (words.len().max(1) as f32);
+        let language = parsed["result"]["language"]
+            .as_str()
+            .unwrap_or("en")
+            .to_string();
+
+        Ok(Transcript {
+            language,
+            words,
+            sentences,
+            avg_confidence,
+        })
     }
-    let sentences = build_sentences(&words);
-    let avg_confidence = words.iter().map(|w| w.p).sum::<f32>() / (words.len().max(1) as f32);
-    let language = parsed["result"]["language"]
-        .as_str()
-        .unwrap_or("en")
-        .to_string();
+    .await;
 
-    Ok(Transcript {
-        language,
-        words,
-        sentences,
-        avg_confidence,
-    })
+    for path in &json_candidates {
+        tokio::fs::remove_file(path).await.ok();
+    }
+    result
 }
 
 fn parse_words(v: &serde_json::Value) -> Vec<Word> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,7 @@
 use anyhow::{bail, Context, Result};
 use serde::Serialize;
 use std::collections::VecDeque;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -119,6 +119,48 @@ pub async fn run_capture(bin: &str, args: &[String]) -> Result<String> {
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
 }
 
+/// Run a quiet subprocess while retaining cancellation control over the child.
+/// `Command::output` owns its child, so it runs in a task that can be aborted;
+/// `kill_on_drop` then terminates the child when cancellation wins the race.
+pub async fn run_capture_cancellable(
+    bin: &str,
+    args: &[String],
+    cancel: &CancellationToken,
+) -> Result<String> {
+    let bin = bin.to_string();
+    let args = args.to_vec();
+    let task_bin = bin.clone();
+    let mut task = tokio::spawn(async move {
+        Command::new(&task_bin)
+            .args(&args)
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .output()
+            .await
+            .with_context(|| format!("failed to start `{}`", task_bin))
+    });
+
+    let out = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            task.abort();
+            let _ = task.await;
+            bail!("cancelled");
+        }
+        result = &mut task => result.context("cancellable subprocess task failed")??,
+    };
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        bail!(
+            "`{}` exited with {} — {}",
+            bin,
+            out.status.code().unwrap_or(-1),
+            err.lines().last().unwrap_or("").trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
 /// Whether this FFmpeg build can burn the generated ASS captions.
 pub async fn ffmpeg_has_ass(bin: &str) -> bool {
     let args = ["-hide_banner".into(), "-filters".into()];
@@ -126,6 +168,14 @@ pub async fn ffmpeg_has_ass(bin: &str) -> bool {
         .await
         .map(|output| filter_list_has(&output, "ass"))
         .unwrap_or(false)
+}
+
+/// Cancellable variant used inside a pipeline run, where an FFmpeg capability
+/// check must not hold cancellation acknowledgement open indefinitely.
+pub async fn ffmpeg_has_ass_cancellable(bin: &str, cancel: &CancellationToken) -> Result<bool> {
+    let args = ["-hide_banner".into(), "-filters".into()];
+    let output = run_capture_cancellable(bin, &args, cancel).await?;
+    Ok(filter_list_has(&output, "ass"))
 }
 
 fn filter_list_has(output: &str, name: &str) -> bool {
@@ -142,7 +192,7 @@ pub async fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent).await.ok();
     }
-    let tmp = path.with_extension("json.tmp");
+    let tmp = unique_temp_path(path);
     tokio::fs::write(&tmp, &json)
         .await
         .with_context(|| format!("writing {}", tmp.display()))?;
@@ -150,6 +200,44 @@ pub async fn atomic_write_json<T: Serialize>(path: &Path, value: &T) -> Result<(
         .await
         .with_context(|| format!("renaming into {}", path.display()))?;
     Ok(())
+}
+
+/// Return a unique sibling path that preserves the final extension so tools
+/// such as FFmpeg still infer the intended container format.
+pub fn unique_temp_path(path: &Path) -> PathBuf {
+    let stem = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("artifact");
+    let suffix = short_id();
+    let name = match path.extension().and_then(|s| s.to_str()) {
+        Some(ext) => format!(".{stem}.part-{suffix}.{ext}"),
+        None => format!(".{stem}.part-{suffix}"),
+    };
+    path.with_file_name(name)
+}
+
+/// Atomically promote a completed sibling artifact into its public path.
+pub async fn promote_atomic(temp: &Path, final_path: &Path) -> Result<()> {
+    if let Some(parent) = final_path.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+    tokio::fs::rename(temp, final_path)
+        .await
+        .with_context(|| format!("promoting {} to {}", temp.display(), final_path.display()))?;
+    Ok(())
+}
+
+/// Atomically write a small marker or other byte payload.
+pub async fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent).await.ok();
+    }
+    let temp = unique_temp_path(path);
+    tokio::fs::write(&temp, bytes)
+        .await
+        .with_context(|| format!("writing {}", temp.display()))?;
+    promote_atomic(&temp, path).await
 }
 
 /// Short, URL-safe project/clip id.
@@ -216,6 +304,7 @@ pub fn which(bin: &str) -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{Duration, Instant};
 
     #[test]
     fn slugify_basic() {
@@ -242,5 +331,33 @@ mod tests {
         let filters = " T. crop V->V Crop video.\n ... ass V->V Render ASS subtitles.\n";
         assert!(filter_list_has(filters, "ass"));
         assert!(!filter_list_has(filters, "subtitles"));
+    }
+
+    #[tokio::test]
+    async fn cancellable_capture_stops_a_slow_child() {
+        let cancel = CancellationToken::new();
+        let trigger = cancel.clone();
+        let canceller = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            trigger.cancel();
+        });
+        let started = Instant::now();
+        let result = run_capture_cancellable("/bin/sleep", &["5".into()], &cancel).await;
+        assert!(result.unwrap_err().to_string().contains("cancelled"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        canceller.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn atomic_promotion_replaces_only_after_the_temp_is_complete() {
+        let dir = std::env::temp_dir().join(format!("cf-atomic-{}", short_id()));
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let final_path = dir.join("clip.mp4");
+        let temp = unique_temp_path(&final_path);
+        tokio::fs::write(&temp, b"complete").await.unwrap();
+        promote_atomic(&temp, &final_path).await.unwrap();
+        assert_eq!(tokio::fs::read(&final_path).await.unwrap(), b"complete");
+        assert!(!temp.exists());
+        tokio::fs::remove_dir_all(&dir).await.ok();
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -106,18 +106,23 @@ pub fn validate(
                 reasons.push(format!("{} quote is empty", label));
                 continue;
             }
-            match excerpt_norm.find(&qn) {
+            let position = if near_start {
+                excerpt_norm.find(&qn)
+            } else {
+                excerpt_norm.rfind(&qn)
+            };
+            match position {
                 None => reasons.push(format!(
                     "{} quote cannot be found in the transcribed excerpt",
                     label
                 )),
                 Some(pos) => {
                     let len = excerpt_norm.len().max(1);
-                    let zone = (len as f64 * 0.5) as usize;
+                    let zone = (len / 4).min(160);
                     let ok = if near_start {
-                        pos <= zone.max(160)
+                        pos <= zone
                     } else {
-                        pos + qn.len() >= len.saturating_sub(zone.max(160))
+                        pos + qn.len() >= len.saturating_sub(zone)
                     };
                     if !ok {
                         reasons.push(format!(
@@ -154,7 +159,7 @@ pub fn validate(
 
     let mut accepted: Vec<ValidatedCandidate> = Vec::new();
     for (cand, duration_exception, composite) in passing {
-        let dur = (cand.end_ms - cand.start_ms).max(1) as f64;
+        let candidate_dur = (cand.end_ms - cand.start_ms).max(1) as f64;
         let too_much_overlap = accepted.iter().any(|a| {
             let inter = crate::select::overlap_ms(
                 a.candidate.start_ms,
@@ -162,7 +167,9 @@ pub fn validate(
                 cand.start_ms,
                 cand.end_ms,
             ) as f64;
-            inter / dur > MAX_OVERLAP
+            let contains_higher_ranked =
+                cand.start_ms <= a.candidate.start_ms && cand.end_ms >= a.candidate.end_ms;
+            contains_higher_ranked || inter / candidate_dur > MAX_OVERLAP
         });
         if too_much_overlap {
             rejected.push(RejectedCandidate {
@@ -449,6 +456,38 @@ mod tests {
     }
 
     #[test]
+    fn closing_quote_uses_the_occurrence_nearest_the_excerpt_end() {
+        let mut t = transcript(200, 400);
+        for start in [10usize, 190] {
+            for (offset, text) in ["we", "finally", "got", "there"].iter().enumerate() {
+                t.words[start + offset].text = (*text).into();
+            }
+        }
+        t.sentences = crate::transcribe::build_sentences(&t.words);
+        let mut c = cand(&t, 0, 80_000, good_scores());
+        c.closing_quote = "we finally got there".into();
+        let r = validate(vec![c], &t, SRC, "t".into());
+        assert_eq!(r.accepted.len(), 1, "reasons: {:?}", r.rejected);
+    }
+
+    #[test]
+    fn closing_quote_in_the_middle_is_not_close_enough_to_the_excerpt_end() {
+        let mut t = transcript(200, 400);
+        for (offset, text) in ["we", "finally", "got", "there"].iter().enumerate() {
+            t.words[150 + offset].text = (*text).into();
+        }
+        t.sentences = crate::transcribe::build_sentences(&t.words);
+        let mut c = cand(&t, 0, 80_000, good_scores());
+        c.closing_quote = "we finally got there".into();
+        let r = validate(vec![c], &t, SRC, "t".into());
+        assert_eq!(r.accepted.len(), 0);
+        assert!(r.rejected[0]
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("closing quote is not near the end")));
+    }
+
+    #[test]
     fn suppresses_overlap_above_30_percent() {
         let t = transcript(1500, 400);
         let strong = cand(&t, 10_000, 70_000, good_scores());
@@ -477,6 +516,42 @@ mod tests {
         let b = cand(&t, 60_000, 120_000, s2);
         let r = validate(vec![a, b], &t, SRC, "t".into());
         assert_eq!(r.accepted.len(), 2);
+    }
+
+    #[test]
+    fn a_candidate_containing_a_higher_ranked_clip_is_rejected_as_overlap() {
+        let t = transcript(1500, 400);
+        let fixture: serde_json::Value =
+            serde_json::from_str(include_str!("../evals/fixtures/overlap_containment.json"))
+                .unwrap();
+        let interval = |name: &str| {
+            (
+                fixture[name]["start_ms"].as_u64().unwrap(),
+                fixture[name]["end_ms"].as_u64().unwrap(),
+            )
+        };
+        assert_eq!(fixture["expected"], "reject-lower-ranked-containing-clip");
+        let (strong_start, strong_end) = interval("higher_ranked");
+        let (containing_start, containing_end) = interval("lower_ranked");
+        let strong = cand(&t, strong_start, strong_end, good_scores());
+        let mut weaker_scores = good_scores();
+        weaker_scores.opening_strength = 3;
+        let containing = cand(&t, containing_start, containing_end, weaker_scores);
+        let r = validate(vec![strong, containing], &t, SRC, "t".into());
+        assert_eq!(r.accepted.len(), 1);
+        assert_eq!(r.rejected.len(), 1);
+        assert!(r.rejected[0].reasons[0].contains("overlaps"));
+    }
+
+    #[test]
+    fn small_overlap_with_a_shorter_higher_ranked_clip_is_allowed() {
+        let t = transcript(1500, 400);
+        let strong = cand(&t, 10_000, 30_000, good_scores());
+        let mut weaker_scores = good_scores();
+        weaker_scores.opening_strength = 3;
+        let mostly_distinct = cand(&t, 23_000, 113_000, weaker_scores);
+        let r = validate(vec![strong, mostly_distinct], &t, SRC, "t".into());
+        assert_eq!(r.accepted.len(), 2, "reasons: {:?}", r.rejected);
     }
 
     #[test]

--- a/static/app.js
+++ b/static/app.js
@@ -19,19 +19,82 @@
   let sse = null;
   let refetchTimer = null;
   let elapsedTimer = null;
+  let uploadXhr = null;
+  let uploadCancelRequested = false;
+  let cancellationPending = false;
+  let retryPending = false;
+  let actionMessageKind = null;
+  let modalReturnFocus = null;
   let liveProgress = null; // {stage, progress, detail}
   // Last style/color the user applied — the starting point for new restyles.
   let captionStyle = localStorage.getItem("cf-caption-style") || "impact";
   let accentColor = localStorage.getItem("cf-accent-color") || "#FFDD00";
   let captionFonts = [];
   let captionDefaultFont = "Inter";
-  const ACCENT_PRESETS = ["#FFDD00", "#7CFF4F", "#FF4F4F", "#4FB5FF", "#C77DFF", "#FF9F1C"];
+  const ACCENT_PRESETS = [
+    { name: "Sun yellow", color: "#FFDD00" },
+    { name: "Lime", color: "#7CFF4F" },
+    { name: "Coral", color: "#FF4F4F" },
+    { name: "Sky blue", color: "#4FB5FF" },
+    { name: "Violet", color: "#C77DFF" },
+    { name: "Orange", color: "#FF9F1C" },
+  ];
   const clipRev = {}; // clip id → cache-busting token after a restyle
+  const restyleState = {}; // clip id → {busy, kind, message, draft}
+
+  function isProcessing(status) { return STAGE_ORDER.includes(status); }
+
+  function formatApiError(payload, status, fallback) {
+    const message = payload && (payload.error || payload.message);
+    if (message) return message;
+    return status ? `${fallback} (${status})` : fallback;
+  }
+
+  async function requestJson(url, options = {}, fallback = "Request failed.") {
+    const res = await fetch(url, options);
+    let payload = null;
+    try {
+      payload = await res.json();
+    } catch {
+      if (res.ok) throw new Error(fallback);
+    }
+    if (!res.ok) throw new Error(formatApiError(payload, res.status, fallback));
+    return payload;
+  }
+
+  function xhrError(xhr, fallback) {
+    let payload = null;
+    try { payload = JSON.parse(xhr.responseText); } catch {}
+    return formatApiError(payload, xhr.status, fallback);
+  }
+
+  function showActionMessage(message, kind = "error") {
+    const banner = $("action-banner");
+    if (!banner) return;
+    actionMessageKind = kind;
+    banner.textContent = message;
+    banner.className = `banner action ${kind === "cancel" ? "notice" : kind}`;
+    banner.classList.remove("hidden");
+  }
+
+  function clearActionMessage(kind = null) {
+    if (kind && actionMessageKind !== kind) return;
+    const banner = $("action-banner");
+    if (!banner) return;
+    actionMessageKind = null;
+    banner.classList.add("hidden");
+  }
+
+  function accentLabel(color) {
+    const normalized = String(color || "").toUpperCase();
+    const preset = ACCENT_PRESETS.find((entry) => entry.color === normalized);
+    return preset ? `${preset.name} (${preset.color})` : `Custom color (${normalized})`;
+  }
 
   // ------------------------------------------------------------------ setup
   async function loadSetup() {
     try {
-      const s = await (await fetch("/api/setup")).json();
+      const s = await requestJson("/api/setup", {}, "Couldn't reconnect to the local server.");
       const problems = [];
       if (!s.ffmpeg) problems.push("FFmpeg was not found. Install it and restart.");
       else if (!s.ffmpeg_ass) problems.push("This FFmpeg build cannot burn captions. macOS: brew install ffmpeg-full, then restart.");
@@ -48,13 +111,16 @@
       } else {
         banner.classList.add("hidden");
       }
+      clearActionMessage("reconnect");
       if (view) render();
-    } catch { /* server will complain loudly enough */ }
+    } catch {
+      showActionMessage("Couldn't reconnect to the local server. Refresh to try again.", "reconnect");
+    }
   }
 
   async function loadSettings() {
     try {
-      const s = await (await fetch("/api/settings/ai")).json();
+      const s = await requestJson("/api/settings/ai", {}, "Couldn't reconnect to the local server.");
       const dot = $("ai-dot");
       dot.className = "dot";
       if (s.provider === "offline") { dot.classList.add("offline"); $("ai-label").textContent = "Local ranking"; }
@@ -63,7 +129,11 @@
       $("provider").value = s.provider || "openai";
       $("model").value = s.model || "";
       syncModalRows();
-    } catch { /* ignore */ }
+      clearActionMessage("reconnect");
+    } catch {
+      $("ai-label").textContent = "AI connection unavailable";
+      showActionMessage("Couldn't reconnect to the local server. Refresh to try again.", "reconnect");
+    }
   }
 
   // ------------------------------------------------------------------ upload
@@ -87,13 +157,14 @@
 
   function wireUploadOptions() {
     const swatchGroup = $("upload-swatches");
-    const swatches = ACCENT_PRESETS.map((color) => {
+    const swatches = ACCENT_PRESETS.map(({ name, color }) => {
       const swatch = document.createElement("button");
       swatch.type = "button";
       swatch.className = "upload-swatch";
       swatch.dataset.color = color;
       swatch.style.setProperty("--swatch", color);
-      swatch.setAttribute("aria-label", `Use ${color}`);
+      swatch.setAttribute("aria-label", `Use ${name} caption highlight, ${color}`);
+      swatch.title = `${name} (${color})`;
       swatchGroup.appendChild(swatch);
       return swatch;
     });
@@ -103,7 +174,7 @@
     function selectColor(color) {
       accentColor = color;
       $("upload-accent-color").value = color;
-      $("upload-accent-hex").textContent = `${color} selected`;
+      $("upload-accent-hex").textContent = `${accentLabel(color)} selected`;
       for (const swatch of swatches) {
         const selected = swatch.dataset.color === color;
         swatch.classList.toggle("active", selected);
@@ -119,12 +190,16 @@
 
   function uploadFile(file) {
     if (!/\.(mp4|m4v)$/i.test(file.name)) {
-      alert("Attach an .mp4 file (the MVP accepts MP4 sources only).");
+      showActionMessage("Attach an .mp4 file. Other containers are not supported yet.");
       return;
     }
+    if (uploadXhr) return;
     $("drop").classList.add("hidden");
     $("upload-progress").classList.remove("hidden");
-    $("upload-label").textContent = `Uploading ${file.name}…`;
+    $("cancel-upload-btn").disabled = false;
+    $("cancel-upload-btn").textContent = "Cancel upload";
+    uploadCancelRequested = false;
+    setUploadPhase(`Uploading ${file.name}…`, 0);
 
     const form = new FormData();
     const framingMode = document.querySelector('input[name="framing-mode"]:checked').value;
@@ -134,40 +209,85 @@
     form.append("accent_color", $("upload-accent-color").value.toUpperCase());
     form.append("file", file, file.name);
     const xhr = new XMLHttpRequest();
+    uploadXhr = xhr;
     xhr.open("POST", "/api/projects");
     xhr.upload.onprogress = (e) => {
-      if (e.lengthComputable) $("upload-bar").style.width = `${(e.loaded / e.total) * 100}%`;
-    };
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) {
-        const v = JSON.parse(xhr.responseText);
-        projectId = v.project.id;
-        localStorage.setItem("cf-project", projectId);
-        view = v;
-        connectSse();
-        render();
-      } else {
-        let msg = "Upload failed.";
-        try { msg = JSON.parse(xhr.responseText).error || msg; } catch {}
-        alert(msg);
-        resetToEmpty();
+      if (e.lengthComputable) {
+        const percent = Math.round((e.loaded / e.total) * 100);
+        setUploadPhase(`Uploading ${file.name}… ${percent}%`, percent);
       }
     };
-    xhr.onerror = () => { alert("Upload failed — is the server still running?"); resetToEmpty(); };
+    xhr.upload.onload = () => {
+      if (uploadXhr === xhr) setUploadPhase(`Preparing ${file.name}…`, 100);
+    };
+    xhr.onload = () => {
+      if (uploadXhr !== xhr) return;
+      uploadXhr = null;
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const v = JSON.parse(xhr.responseText);
+          projectId = v.project.id;
+          localStorage.setItem("cf-project", projectId);
+          view = v;
+          clearActionMessage();
+          connectSse();
+          render();
+        } catch {
+          resetToEmpty({ message: "The server returned an invalid project response. Try again." });
+        }
+      } else {
+        resetToEmpty({ message: xhrError(xhr, "Upload failed.") });
+      }
+    };
+    xhr.onabort = () => {
+      if (uploadXhr !== xhr) return;
+      uploadXhr = null;
+      const message = uploadCancelRequested
+        ? "Upload cancelled. Choose another MP4."
+        : "Upload stopped before it finished. Try again.";
+      resetToEmpty({ message, kind: uploadCancelRequested ? "notice" : "error" });
+    };
+    xhr.onerror = () => {
+      if (uploadXhr !== xhr) return;
+      uploadXhr = null;
+      resetToEmpty({ message: "Upload failed. Check that the local server is still running." });
+    };
     xhr.send(form);
   }
 
-  function resetToEmpty() {
+  function setUploadPhase(label, percent) {
+    $("upload-label").textContent = label;
+    if (percent != null) {
+      $("upload-bar").style.width = `${percent}%`;
+      $("upload-bar").parentElement.setAttribute("aria-valuenow", String(percent));
+    }
+  }
+
+  function cancelUpload() {
+    if (!uploadXhr) return;
+    uploadCancelRequested = true;
+    $("cancel-upload-btn").disabled = true;
+    $("cancel-upload-btn").textContent = "Cancelling…";
+    setUploadPhase("Cancelling upload…", null);
+    uploadXhr.abort();
+  }
+
+  function resetToEmpty({ message = null, kind = "error" } = {}) {
     projectId = null;
     view = null;
     liveProgress = null;
+    cancellationPending = false;
+    retryPending = false;
+    uploadCancelRequested = false;
     localStorage.removeItem("cf-project");
     if (sse) { sse.close(); sse = null; }
     $("drop").classList.remove("hidden");
     $("upload-progress").classList.add("hidden");
     $("upload-bar").style.width = "0%";
+    $("upload-bar").parentElement.setAttribute("aria-valuenow", "0");
     $("file-input").value = "";
     render();
+    if (message) showActionMessage(message, kind);
   }
 
   // ------------------------------------------------------------------ data
@@ -175,10 +295,25 @@
     if (!projectId) return;
     try {
       const res = await fetch(`/api/projects/${projectId}`);
-      if (res.status === 404) { resetToEmpty(); return; }
-      view = await res.json();
+      if (res.status === 404) {
+        resetToEmpty({ message: "This project is no longer available. Choose another MP4." });
+        return;
+      }
+      let payload = null;
+      try { payload = await res.json(); } catch { throw new Error("The server returned an invalid project response."); }
+      if (!res.ok) throw new Error(formatApiError(payload, res.status, "Couldn't refresh project status."));
+      view = payload;
+      if (!isProcessing(view.project.status)) {
+        if (cancellationPending) {
+          cancellationPending = false;
+          clearActionMessage("cancel");
+        }
+      }
+      clearActionMessage("reconnect");
       render();
-    } catch { /* transient */ }
+    } catch (err) {
+      showActionMessage(`${err.message} Live progress will retry.`, "reconnect");
+    }
   }
 
   function scheduleRefetch() {
@@ -193,9 +328,10 @@
     sse.onmessage = (e) => {
       let msg = {};
       try { msg = JSON.parse(e.data); } catch { return; }
-      if (msg.type === "snapshot" && msg.view) { view = msg.view; render(); return; }
+      if (msg.type === "snapshot" && msg.view) { view = msg.view; clearActionMessage("reconnect"); render(); return; }
       if (msg.type === "progress") {
         liveProgress = { stage: msg.stage, progress: msg.progress, detail: msg.detail };
+        clearActionMessage("reconnect");
         renderLive();
         return;
       }
@@ -203,7 +339,9 @@
       liveProgress = null;
       scheduleRefetch();
     };
-    sse.onerror = () => { /* EventSource auto-reconnects */ };
+    sse.onerror = () => {
+      showActionMessage("Live progress disconnected. Reconnecting…", "reconnect");
+    };
   }
 
   // ------------------------------------------------------------------ render
@@ -212,10 +350,17 @@
     $("upload-state").classList.toggle("hidden", !!p);
     $("processing-state").classList.toggle("hidden", !p);
     if (!p) { $("results-state").classList.add("hidden"); stopElapsed(); return; }
+    if (!isProcessing(p.status)) {
+      if (cancellationPending) {
+        cancellationPending = false;
+        clearActionMessage("cancel");
+      }
+    }
 
     // Source line
     const src = p.source;
     $("source-name").textContent = view.original_name || "source.mp4";
+    $("source-name").title = view.original_name || "source.mp4";
     $("source-meta").textContent = src
       ? `${src.width}×${src.height} · ${fmtMs(src.duration_ms)} · ${src.video_codec}/${src.audio_codec}`
       : "";
@@ -249,6 +394,7 @@
       const div = document.createElement("div");
       div.className = `step ${st === "pending" ? "" : st}`;
       div.dataset.stage = name;
+      div.setAttribute("role", "listitem");
       const status =
         st === "failed" ? "Failed" :
         st === "done" ? (rec.detail || "Done") :
@@ -256,6 +402,7 @@
       div.innerHTML = `<strong>${STAGE_LABELS[name]}</strong><span class="status"></span>` +
         (st === "active" ? `<div class="mini-bar"><div class="mini-fill"></div></div>` : "");
       div.querySelector(".status").textContent = status;
+      div.setAttribute("aria-label", `${STAGE_LABELS[name]}${status ? `: ${status}` : ": pending"}`);
       wrap.appendChild(div);
     }
     renderLive();
@@ -267,31 +414,47 @@
     const step = document.querySelector(`.step[data-stage="${liveProgress.stage}"] .mini-fill`);
     if (step) step.style.width = `${Math.round((liveProgress.progress || 0) * 100)}%`;
     const status = document.querySelector(`.step[data-stage="${liveProgress.stage}"] .status`);
-    if (status && liveProgress.detail) status.textContent = liveProgress.detail;
+    if (status && liveProgress.detail) {
+      status.textContent = liveProgress.detail;
+      status.parentElement.setAttribute("aria-label", `${STAGE_LABELS[liveProgress.stage] || liveProgress.stage}: ${liveProgress.detail}`);
+    }
     if (liveProgress.detail) $("current-op-text").textContent = liveProgress.detail;
     else if (liveProgress.progress != null)
       $("current-op-text").textContent =
-        `${STAGE_LABELS[liveProgress.stage] || liveProgress.stage} — ${Math.round(liveProgress.progress * 100)}%`;
+        `${STAGE_LABELS[liveProgress.stage] || liveProgress.stage} · ${Math.round(liveProgress.progress * 100)}%`;
   }
 
   function renderCurrentOp(p) {
-    const active = STAGE_ORDER.includes(p.status);
+    const active = isProcessing(p.status);
     $("current-op").classList.toggle("hidden", !active);
     $("cancel-btn").classList.toggle("hidden", !active);
+    $("cancel-btn").disabled = cancellationPending;
+    $("cancel-btn").textContent = cancellationPending ? "Cancelling…" : "Cancel";
     if (active) {
       const label = STAGE_LABELS[p.status] || p.status;
-      $("current-op-text").textContent = label.replace(/^\d+\.\s*/, "") + "…";
+      $("current-op-text").textContent = cancellationPending
+        ? "Cancelling…"
+        : label.replace(/^\d+\.\s*/, "") + "…";
     }
   }
 
   function renderError(p) {
     const box = $("error-box");
-    if (p.status === "failed" && p.error) {
+    const clips = view.clips || [];
+    const chooseAnother = $("choose-another-btn");
+    const retryButton = $("retry-btn");
+    const zeroClipFailure = clips.length === 0 && (p.status === "failed" || p.status === "cancelled");
+    chooseAnother.classList.toggle("hidden", !zeroClipFailure);
+    retryButton.disabled = retryPending;
+    retryButton.textContent = retryPending
+      ? "Retrying…"
+      : p.status === "cancelled" ? "Retry processing" : "Retry stage";
+    if (p.status === "failed") {
       const failedStage = p.stages.find((s) => s.error);
       $("error-stage").textContent = failedStage
         ? `${STAGE_LABELS[failedStage.name] || failedStage.name} failed`
         : "Processing failed";
-      $("error-text").textContent = p.error;
+      $("error-text").textContent = p.error || "Processing failed. Try again or choose another MP4.";
       box.classList.remove("hidden");
     } else if (p.status === "cancelled") {
       $("error-stage").textContent = "Cancelled";
@@ -306,6 +469,7 @@
     const section = $("results-state");
     const clips = (view.clips || []);
     const ready = clips.filter((c) => c.status === "ready");
+    const failed = clips.filter((c) => c.status === "failed");
     const showResults = clips.length > 0 || p.status === "complete";
     section.classList.toggle("hidden", !showResults);
     if (!showResults) return;
@@ -313,13 +477,35 @@
     const total = clips.length;
     $("results-title").textContent =
       total === 0 ? "No clips produced" :
-      p.status === "complete"
+      failed.length > 0
+        ? `${ready.length} of ${total} clips ready · ${failed.length} failed`
+        : p.status === "complete"
         ? `${ready.length} strong clip${ready.length === 1 ? "" : "s"} found`
         : `${ready.length} of ${total} clips ready`;
 
     const sel = view.selector ? ` Selected by ${view.selector}.` : "";
+    const count = total > 0 ? ` ${ready.length} ready${failed.length ? `, ${failed.length} failed` : ""}.` : "";
     $("results-sub").textContent =
-      `Ranked by self-contained opening, tension, payoff, and clarity.${sel}`;
+      `Ranked by self-contained opening, tension, payoff, and clarity.${count}${sel}`;
+
+    const openFolder = $("open-folder-btn");
+    const outputAvailable = typeof view.output_dir === "string" && view.output_dir.trim().length > 0;
+    openFolder.disabled = !outputAvailable || ready.length === 0;
+    openFolder.title = openFolder.disabled
+      ? "Available after at least one clip is ready and saved."
+      : "Open the folder containing the ready clips";
+    const newProject = $("new-project-btn");
+    const active = isProcessing(p.status);
+    const restyleBusy = Object.values(restyleState).some((state) => state.busy);
+    newProject.disabled = cancellationPending || restyleBusy;
+    newProject.textContent = restyleBusy
+      ? "Applying captions…"
+      : active
+      ? cancellationPending ? "Cancelling…" : "Cancel & start over"
+      : "New project";
+    newProject.title = active
+      ? "Cancel processing first. Completed clips will stay available."
+      : "Leave this project and choose another MP4";
 
     // Empty (quality bar) state
     $("empty-results").classList.toggle("hidden", !(p.status === "complete" && total === 0));
@@ -358,8 +544,36 @@
       v.controls = true;
       v.preload = "metadata";
       v.playsInline = true;
+      v.setAttribute("aria-label", `Preview clip ${c.rank}: ${c.headline}`);
       v.src = `/api/projects/${projectId}/clips/${c.id}` +
         (clipRev[c.id] ? `?rev=${clipRev[c.id]}` : "");
+      const pendingPreview = restyleState[c.id];
+      if (pendingPreview && pendingPreview.awaitingPreview) {
+        v.addEventListener("loadedmetadata", () => {
+          const state = restyleState[c.id];
+          if (!state || !state.awaitingPreview) return;
+          state.awaitingPreview = false;
+          state.kind = "success";
+          state.message = "Captions applied";
+          const status = row.querySelector(".restyle-status");
+          if (status) {
+            status.className = "small restyle-status success";
+            status.textContent = state.message;
+          }
+        }, { once: true });
+        v.addEventListener("error", () => {
+          const state = restyleState[c.id];
+          if (!state || !state.awaitingPreview) return;
+          state.awaitingPreview = false;
+          state.kind = "status-error";
+          state.message = "Captions saved, but the preview could not reload";
+          const status = row.querySelector(".restyle-status");
+          if (status) {
+            status.className = "small restyle-status status-error";
+            status.textContent = state.message;
+          }
+        }, { once: true });
+      }
       preview.appendChild(v);
     } else if (c.status === "rendering") {
       preview.innerHTML = `<span class="spinner"></span>`;
@@ -395,12 +609,16 @@
     actions.className = "actions";
     if (c.status === "ready") {
       const a = document.createElement("a");
+      a.className = "primary action-button";
       a.href = `/api/projects/${projectId}/clips/${c.id}/download`;
-      a.innerHTML = `<button class="primary" type="button">Download MP4</button>`;
+      a.download = c.filename;
+      a.setAttribute("aria-label", `Download clip ${c.rank}: ${c.headline}`);
+      a.textContent = "Download MP4";
       actions.appendChild(a);
     } else if (c.status === "failed") {
       const b = document.createElement("button");
-      b.textContent = "Retry failed clips";
+      b.textContent = retryPending ? "Retrying…" : "Retry failed clips";
+      b.disabled = retryPending;
       b.addEventListener("click", retry);
       actions.appendChild(b);
     }
@@ -416,62 +634,101 @@
   function restyleControls(c) {
     const box = document.createElement("div");
     box.className = "restyle";
-    let selStyle = c.caption_style || captionStyle;
-    let selColor = (c.accent_color || accentColor).toUpperCase();
-    let selFont = c.caption_font || captionDefaultFont;
-    let fontChanged = false;
+    box.setAttribute("role", "group");
+    box.setAttribute("aria-label", `Caption settings for ${c.headline}`);
+    const applied = {
+      style: c.caption_style || captionStyle,
+      color: (c.accent_color || accentColor).toUpperCase(),
+      font: c.caption_font || captionDefaultFont,
+    };
+    const state = restyleState[c.id] || { draft: { ...applied } };
+    state.draft = state.draft || { ...applied };
+    restyleState[c.id] = state;
 
     const label = document.createElement("span");
     label.className = "muted small restyle-label";
-    label.textContent = "Captions";
+    label.textContent = "Caption settings";
 
     const seg = document.createElement("div");
     seg.className = "seg";
+    seg.setAttribute("role", "group");
+    seg.setAttribute("aria-label", "Caption style");
     const styleBtns = ["impact", "clean"].map((s) => {
       const b = document.createElement("button");
       b.type = "button";
       b.className = "seg-btn";
       b.textContent = s === "impact" ? "Impact" : "Clean";
-      b.addEventListener("click", () => { selStyle = s; sync(); });
+      b.setAttribute("aria-pressed", "false");
+      b.addEventListener("click", () => {
+        state.draft.style = s;
+        state.kind = "dirty";
+        state.message = "Unsaved caption changes";
+        sync();
+      });
       seg.appendChild(b);
       return [s, b];
     });
 
     const swatches = document.createElement("div");
     swatches.className = "swatches";
-    const swatchBtns = ACCENT_PRESETS.map((color) => {
+    swatches.setAttribute("role", "group");
+    swatches.setAttribute("aria-label", "Caption highlight color");
+    const swatchBtns = ACCENT_PRESETS.map(({ name, color }) => {
       const b = document.createElement("button");
       b.type = "button";
       b.className = "swatch";
       b.style.background = color;
-      b.title = color;
-      b.addEventListener("click", () => { selColor = color; sync(); });
+      b.setAttribute("aria-label", `Use ${name} caption highlight, ${color}`);
+      b.setAttribute("aria-pressed", "false");
+      b.title = `${name} (${color})`;
+      b.addEventListener("click", () => {
+        state.draft.color = color;
+        state.kind = "dirty";
+        state.message = "Unsaved caption changes";
+        sync();
+      });
       swatches.appendChild(b);
       return [color, b];
     });
+    const customPicker = document.createElement("label");
+    customPicker.className = "custom-color-picker";
+    const customLabel = document.createElement("span");
+    customLabel.textContent = "Custom";
     const custom = document.createElement("input");
     custom.type = "color";
     custom.className = "custom-color";
-    custom.title = "Custom color";
-    custom.addEventListener("input", (e) => { selColor = e.target.value.toUpperCase(); sync(); });
-    swatches.appendChild(custom);
+    custom.setAttribute("aria-label", "Custom caption highlight color");
+    custom.title = "Custom caption highlight color";
+    custom.setAttribute("aria-pressed", "false");
+    custom.addEventListener("input", (e) => {
+      state.draft.color = e.target.value.toUpperCase();
+      state.kind = "dirty";
+      state.message = "Unsaved caption changes";
+      sync();
+    });
+    customPicker.appendChild(customLabel);
+    customPicker.appendChild(custom);
+    swatches.appendChild(customPicker);
 
     const font = document.createElement("select");
     font.className = "font-select";
+    font.setAttribute("aria-label", "Caption font");
     font.title = "Caption font";
-    const availableFonts = captionFonts.includes(selFont)
+    const availableFonts = captionFonts.includes(state.draft.font)
       ? captionFonts
-      : [selFont, ...captionFonts];
+      : [state.draft.font, ...captionFonts];
     for (const name of availableFonts) {
       const option = document.createElement("option");
       option.value = name;
       option.textContent = name;
-      option.selected = name === selFont;
+      option.selected = name === state.draft.font;
       font.appendChild(option);
     }
     font.addEventListener("change", () => {
-      selFont = font.value;
-      fontChanged = true;
+      state.draft.font = font.value;
+      state.kind = "dirty";
+      state.message = "Unsaved caption changes";
+      sync();
     });
     const fontPicker = document.createElement("label");
     fontPicker.className = "font-picker";
@@ -482,43 +739,87 @@
 
     const apply = document.createElement("button");
     apply.type = "button";
-    apply.textContent = "Apply";
+    apply.className = "apply-captions";
+    apply.textContent = "Apply captions";
     const status = document.createElement("span");
     status.className = "muted small restyle-status";
+    status.setAttribute("role", "status");
+    status.setAttribute("aria-live", "polite");
 
     function sync() {
-      for (const [s, b] of styleBtns) b.classList.toggle("active", s === selStyle);
-      for (const [color, b] of swatchBtns) b.classList.toggle("active", color === selColor);
-      custom.classList.toggle("active", !ACCENT_PRESETS.includes(selColor));
-      custom.value = selColor;
+      state.dirty = (
+        state.draft.style !== applied.style ||
+        state.draft.color !== applied.color ||
+        state.draft.font !== applied.font
+      );
+      if (!state.dirty && state.kind === "dirty") {
+        state.kind = null;
+        state.message = "";
+      }
+      for (const [s, b] of styleBtns) {
+        const selected = s === state.draft.style;
+        b.classList.toggle("active", selected);
+        b.setAttribute("aria-pressed", String(selected));
+      }
+      for (const [color, b] of swatchBtns) {
+        const selected = color === state.draft.color;
+        b.classList.toggle("active", selected);
+        b.setAttribute("aria-pressed", String(selected));
+      }
+      const customSelected = !ACCENT_PRESETS.some((entry) => entry.color === state.draft.color);
+      custom.classList.toggle("active", customSelected);
+      custom.setAttribute("aria-pressed", String(customSelected));
+      custom.value = state.draft.color;
+      font.value = state.draft.font;
+      apply.disabled = Boolean(state.busy) || !state.dirty;
+      apply.textContent = state.busy ? "Applying…" : "Apply captions";
+      status.className = `small restyle-status ${state.kind || ""}`;
+      status.textContent = state.message || "";
     }
 
     apply.addEventListener("click", async () => {
-      apply.disabled = true;
-      apply.textContent = "Restyling…";
-      status.textContent = "Re-burning captions…";
+      if (state.busy || !state.dirty) return;
+      state.busy = true;
+      state.kind = "busy";
+      state.message = "Applying captions…";
+      sync();
       try {
-        const payload = { style: selStyle, accent_color: selColor };
-        if (fontChanged) payload.font = selFont;
-        const res = await fetch(`/api/projects/${projectId}/clips/${c.id}/restyle`, {
+        const requestProjectId = projectId;
+        const updated = await requestJson(`/api/projects/${projectId}/clips/${c.id}/restyle`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-        if (!res.ok) throw new Error((await res.json()).error || "Restyle failed.");
-        const updated = await res.json();
-        captionStyle = selStyle;
-        accentColor = selColor;
+          body: JSON.stringify({
+            style: state.draft.style,
+            accent_color: state.draft.color,
+            font: state.draft.font,
+          }),
+        }, "Captions could not be updated.");
+        captionStyle = state.draft.style;
+        accentColor = state.draft.color;
         localStorage.setItem("cf-caption-style", captionStyle);
         localStorage.setItem("cf-accent-color", accentColor);
         clipRev[c.id] = Date.now();
+        state.busy = false;
+        if (!view || projectId !== requestProjectId) return;
         const i = (view.clips || []).findIndex((x) => x.id === c.id);
         if (i >= 0) view.clips[i] = updated;
+        state.dirty = false;
+        state.awaitingPreview = true;
+        state.kind = "busy";
+        state.message = "Captions saved. Refreshing preview…";
+        state.draft = {
+          style: updated.caption_style || state.draft.style,
+          color: (updated.accent_color || state.draft.color).toUpperCase(),
+          font: updated.caption_font || state.draft.font,
+        };
         render();
       } catch (err) {
-        status.textContent = err.message;
-        apply.disabled = false;
-        apply.textContent = "Apply";
+        state.busy = false;
+        state.dirty = true;
+        state.kind = "status-error";
+        state.message = err.message;
+        render();
+        showActionMessage(`Captions for “${c.headline}” failed: ${err.message}`);
       }
     });
 
@@ -547,18 +848,80 @@
 
   // ------------------------------------------------------------------ actions
   async function cancel() {
-    if (!projectId) return;
-    await fetch(`/api/projects/${projectId}/cancel`, { method: "POST" });
+    if (!projectId || cancellationPending || !isProcessing(view && view.project && view.project.status)) return false;
+    cancellationPending = true;
+    render();
+    showActionMessage("Cancellation requested. Waiting for the active stage to stop…", "cancel");
+    try {
+      const result = await requestJson(
+        `/api/projects/${projectId}/cancel`,
+        { method: "POST" },
+        "Couldn't cancel processing."
+      );
+      if (result.cancelled) showActionMessage("Processing cancelled. Finished clips were kept.", "notice");
+      else showActionMessage("Processing had already stopped. Refreshing its status…", "notice");
+      scheduleRefetch();
+      return true;
+    } catch (err) {
+      cancellationPending = false;
+      render();
+      showActionMessage(err.message);
+      return false;
+    }
   }
+
   async function retry() {
-    if (!projectId) return;
-    await fetch(`/api/projects/${projectId}/retry`, { method: "POST" });
-    scheduleRefetch();
+    if (!projectId || retryPending) return;
+    retryPending = true;
+    render();
+    try {
+      await requestJson(`/api/projects/${projectId}/retry`, { method: "POST" }, "Couldn't retry processing.");
+      showActionMessage("Retry started. Completed work will be kept.", "notice");
+      await refetch();
+      retryPending = false;
+      render();
+    } catch (err) {
+      retryPending = false;
+      render();
+      showActionMessage(err.message);
+    }
   }
+
   async function openFolder() {
-    if (!projectId) return;
-    const r = await (await fetch(`/api/projects/${projectId}/open-output-folder`, { method: "POST" })).json();
-    if (!r.opened) alert(`Clips are saved to:\n${r.path}`);
+    const ready = (view && view.clips || []).filter((c) => c.status === "ready");
+    if (!projectId || !view || !view.output_dir || ready.length === 0) {
+      showActionMessage("The output folder becomes available after a clip is ready and saved.");
+      return;
+    }
+    try {
+      const result = await requestJson(
+        `/api/projects/${projectId}/open-output-folder`,
+        { method: "POST" },
+        "Couldn't open the output folder."
+      );
+      if (result.opened) clearActionMessage();
+      else showActionMessage(result.path ? `Open the clips manually at ${result.path}.` : "The output folder could not be opened.", "notice");
+    } catch (err) {
+      showActionMessage(err.message);
+    }
+  }
+
+  async function handleNewProject() {
+    if (uploadXhr) {
+      cancelUpload();
+      return;
+    }
+    if (view && isProcessing(view.project.status)) {
+      if (await cancel()) {
+        resetToEmpty({ message: "Processing cancelled. Finished clips remain on disk.", kind: "notice" });
+      }
+      return;
+    }
+    if (Object.values(restyleState).some((state) => state.busy)) {
+      showActionMessage("Wait for the caption update to finish before starting another project.", "notice");
+      return;
+    }
+    resetToEmpty();
   }
 
   // ------------------------------------------------------------------ modal
@@ -570,12 +933,55 @@
     $("model").placeholder = $("provider").value === "anthropic" ? "claude-sonnet-4-5" : "gpt-4o-mini";
   }
 
+  function modalFocusables() {
+    return [...$("modal-backdrop").querySelectorAll("button, input, select, [href]")]
+      .filter((el) => !el.disabled && el.getClientRects().length > 0);
+  }
+
+  function openModal() {
+    modalReturnFocus = document.activeElement;
+    $("modal-backdrop").classList.remove("hidden");
+    $("modal-backdrop").setAttribute("aria-hidden", "false");
+    document.body.classList.add("modal-open");
+    syncModalRows();
+    requestAnimationFrame(() => $("provider").focus());
+  }
+
+  function closeModal() {
+    $("modal-backdrop").classList.add("hidden");
+    $("modal-backdrop").setAttribute("aria-hidden", "true");
+    document.body.classList.remove("modal-open");
+    $("test-result").classList.add("hidden");
+    $("api-key").value = "";
+    if (modalReturnFocus && typeof modalReturnFocus.focus === "function") modalReturnFocus.focus();
+    modalReturnFocus = null;
+  }
+
   function wireModal() {
-    $("ai-btn").addEventListener("click", () => $("modal-backdrop").classList.remove("hidden"));
-    $("modal-close").addEventListener("click", () => {
-      $("modal-backdrop").classList.add("hidden");
-      $("test-result").classList.add("hidden");
-      $("api-key").value = "";
+    $("ai-btn").addEventListener("click", openModal);
+    $("modal-close").addEventListener("click", closeModal);
+    $("modal-backdrop").addEventListener("click", (e) => {
+      if (e.target === $("modal-backdrop")) closeModal();
+    });
+    document.addEventListener("keydown", (e) => {
+      if ($("modal-backdrop").classList.contains("hidden")) return;
+      if (e.key === "Escape") {
+        e.preventDefault();
+        closeModal();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = modalFocusables();
+      if (!focusables.length) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     });
     $("provider").addEventListener("change", syncModalRows);
     $("test-save").addEventListener("click", async () => {
@@ -583,7 +989,7 @@
       btn.disabled = true;
       btn.textContent = "Testing…";
       try {
-        const res = await fetch("/api/settings/ai", {
+        const saved = await requestJson("/api/settings/ai", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
@@ -591,20 +997,21 @@
             model: $("model").value.trim(),
             api_key: $("api-key").value.trim(),
           }),
-        });
-        if (!res.ok) throw new Error((await res.json()).error || "Could not save settings.");
-        const test = await (await fetch("/api/settings/ai/test", { method: "POST" })).json();
+        }, "Could not save AI settings.");
         const out = $("test-result");
-        out.textContent = test.message;
-        out.className = `small ${test.ok ? "ok" : "bad"}`;
+        out.textContent = saved.provider === "offline"
+          ? "Local ranking is ready — no API key needed."
+          : `${saved.provider === "anthropic" ? "Anthropic" : "OpenAI"} connection verified. Using model ${saved.model}.`;
+        out.className = "small ok";
         out.classList.remove("hidden");
-        if (test.ok) $("api-key").value = "";
-        loadSettings();
+        $("api-key").value = "";
+        await loadSettings();
       } catch (err) {
         const out = $("test-result");
         out.textContent = err.message;
         out.className = "small bad";
         out.classList.remove("hidden");
+        showActionMessage(err.message);
       } finally {
         btn.disabled = false;
         btn.textContent = "Test & save";
@@ -625,10 +1032,12 @@
     wireUpload();
     wireUploadOptions();
     wireModal();
+    $("cancel-upload-btn").addEventListener("click", cancelUpload);
     $("cancel-btn").addEventListener("click", cancel);
     $("retry-btn").addEventListener("click", retry);
+    $("choose-another-btn").addEventListener("click", resetToEmpty);
     $("open-folder-btn").addEventListener("click", openFolder);
-    $("new-project-btn").addEventListener("click", resetToEmpty);
+    $("new-project-btn").addEventListener("click", handleNewProject);
     loadSetup();
     loadSettings();
     if (projectId) {

--- a/static/index.html
+++ b/static/index.html
@@ -19,11 +19,13 @@
       </button>
     </header>
 
-    <div id="setup-banner" class="banner hidden"></div>
-    <div id="warning-banner" class="banner warn hidden"></div>
+    <div id="setup-banner" class="banner hidden" role="alert" aria-live="assertive"></div>
+    <div id="warning-banner" class="banner warn hidden" role="status" aria-live="polite"></div>
+    <div id="action-banner" class="banner action hidden" role="alert" aria-live="assertive"></div>
 
     <!-- Empty / import state -->
-    <section id="upload-state">
+    <section id="upload-state" aria-labelledby="upload-title">
+      <h2 id="upload-title" class="sr-only">Create clips</h2>
       <div id="drop" class="upload">
         <strong>Drop one podcast MP4 here</strong>
         <p class="muted">The original stays on this computer. Clips keep the original conversation intact — one continuous excerpt each, no invented speech.</p>
@@ -43,7 +45,7 @@
         <fieldset class="accent-choice">
           <legend>Caption highlight</legend>
           <div class="accent-option accent-palette">
-            <input type="radio" name="accent-mode" value="manual" checked>
+              <input type="radio" name="accent-mode" value="manual" aria-label="Choose a caption highlight color" checked>
             <div>
               <strong>Choose a color</strong>
               <div id="upload-swatches" class="upload-swatches" role="group" aria-label="Caption highlight colors"></div>
@@ -65,14 +67,20 @@
         <p class="muted small">Supported input: MP4 with at least one audio stream, 20 seconds to 4 hours.<br>
         You can still change captions, color, and font on each finished clip.</p>
       </div>
-      <div id="upload-progress" class="hidden">
-        <p id="upload-label">Uploading…</p>
-        <div class="bar"><div id="upload-bar" class="bar-fill"></div></div>
+      <div id="upload-progress" class="hidden" aria-live="polite">
+        <div class="upload-progress-head">
+          <p id="upload-label" role="status">Uploading…</p>
+          <button id="cancel-upload-btn" type="button">Cancel upload</button>
+        </div>
+        <div class="bar" role="progressbar" aria-label="Upload progress" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+          <div id="upload-bar" class="bar-fill"></div>
+        </div>
       </div>
     </section>
 
     <!-- Processing state -->
-    <section id="processing-state" class="hidden">
+    <section id="processing-state" class="hidden" aria-labelledby="processing-title">
+      <h2 id="processing-title" class="sr-only">Processing</h2>
       <div class="source-line">
         <div>
           <span id="source-name" class="source-name"></span>
@@ -80,26 +88,29 @@
         </div>
         <button id="cancel-btn" type="button">Cancel</button>
       </div>
-      <div id="stages" class="progress"></div>
+      <div id="stages" class="progress" role="list" aria-label="Processing stages"></div>
       <div id="current-op" class="current-op hidden">
         <span class="spinner"></span>
-        <span id="current-op-text"></span>
-        <span id="elapsed" class="muted"></span>
+        <span id="current-op-text" role="status" aria-live="polite" aria-atomic="true"></span>
+        <span id="elapsed" class="muted" aria-hidden="true"></span>
       </div>
-      <div id="error-box" class="error hidden">
+      <div id="error-box" class="error hidden" role="alert" aria-live="assertive">
         <div>
           <strong id="error-stage"></strong>
           <p id="error-text"></p>
         </div>
-        <button id="retry-btn" class="primary" type="button">Retry stage</button>
+        <div class="error-actions">
+          <button id="choose-another-btn" type="button" class="hidden">Choose another MP4</button>
+          <button id="retry-btn" class="primary" type="button">Retry stage</button>
+        </div>
       </div>
     </section>
 
     <!-- Results state -->
-    <section id="results-state" class="hidden">
+    <section id="results-state" class="hidden" aria-labelledby="results-title">
       <div class="results-head">
         <div>
-          <h2 id="results-title"></h2>
+          <h2 id="results-title" aria-live="polite"></h2>
           <p class="muted" id="results-sub">Ranked by self-contained opening, tension, payoff, and clarity.</p>
         </div>
         <div class="results-actions">
@@ -124,10 +135,10 @@
   </div>
 
   <!-- AI connection modal -->
-  <div id="modal-backdrop" class="modal-backdrop hidden">
-    <div class="modal">
-      <h3>AI connection</h3>
-      <p class="muted small">The editorial selector proposes which moments stand alone. Your key is stored locally with user-only permissions, never logged, and never shown again.</p>
+  <div id="modal-backdrop" class="modal-backdrop hidden" aria-hidden="true">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="ai-modal-title" aria-describedby="ai-modal-description">
+      <h3 id="ai-modal-title">AI connection</h3>
+      <p id="ai-modal-description" class="muted small">The editorial selector proposes which moments stand alone. Your key is stored locally with user-only permissions, never logged, and never shown again.</p>
       <label>Provider
         <select id="provider">
           <option value="openai">OpenAI</option>
@@ -144,7 +155,7 @@
       <p id="offline-note" class="muted small hidden">Local ranking scans the full transcript for strong openings, reactions, repeated claims, clean endings, and standalone clarity. No model or API key is required.</p>
       <p id="test-result" class="small hidden"></p>
       <div class="modal-actions">
-        <button id="modal-close" type="button">Close</button>
+        <button id="modal-close" type="button" aria-label="Close AI connection dialog">Close</button>
         <button id="test-save" class="primary" type="button">Test &amp; save</button>
       </div>
     </div>

--- a/static/styles.css
+++ b/static/styles.css
@@ -2,6 +2,8 @@
 
 * { box-sizing: border-box; }
 
+html { color-scheme: light; }
+
 :root {
   --paper: #f5f5f3;
   --ink: #1d1d1b;
@@ -17,7 +19,7 @@ body {
   margin: 0;
   background: var(--paper);
   color: var(--ink);
-  font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", sans-serif;
+  font: 16px/1.5 "Avenir Next", "Segoe UI", sans-serif;
 }
 
 .shell { max-width: 1180px; margin: 0 auto; padding: 28px 24px 60px; }
@@ -27,19 +29,30 @@ button {
   border: 1px solid #8a8a84;
   border-radius: 5px;
   background: #fff;
+  min-height: 44px;
   padding: 9px 14px;
   cursor: pointer;
 }
 button:hover { border-color: var(--ink); }
-button.primary { background: var(--ink); color: #fff; border-color: var(--ink); }
-button.primary:hover { background: #000; }
-button:disabled { opacity: .45; cursor: default; }
+button.primary, .primary { background: var(--ink); color: #fff; border-color: var(--ink); }
+button.primary:hover, .primary:hover { background: #000; }
+button:disabled, .primary:disabled { opacity: .45; cursor: not-allowed; }
+a { color: inherit; }
+.action-button { display: inline-flex; align-items: center; justify-content: center; text-decoration: none; }
+button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible, summary:focus-visible {
+  outline: 3px solid #4f46e5;
+  outline-offset: 2px;
+}
+.sr-only {
+  position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
 
 h1, h2, h3, p { margin-top: 0; }
-h1 { font-size: 19px; margin-bottom: 2px; letter-spacing: -0.01em; }
-h2 { font-size: 17px; margin-bottom: 2px; }
+h1 { font-size: 20px; margin-bottom: 2px; letter-spacing: -0.01em; }
+h2 { font-size: 20px; margin-bottom: 2px; }
 .muted { color: var(--muted); }
-.small { font-size: 12.5px; }
+.small { font-size: 13px; }
 .hidden { display: none !important; }
 
 header {
@@ -55,9 +68,11 @@ header {
 .banner {
   margin: 18px 0 0; padding: 11px 14px; font-size: 13px;
   border: 1px solid var(--hairline); border-left: 3px solid #8a8a84;
-  background: #fbfbf9; border-radius: 4px; white-space: pre-line;
+  background: #fbfbf9; border-radius: 4px; white-space: pre-line; overflow-wrap: anywhere;
 }
 .banner.warn { border-left-color: var(--accent); }
+.banner.action { border-left-color: var(--bad); background: #fdf6f5; }
+.banner.action.notice { border-left-color: var(--accent); background: #fffaf0; }
 
 /* ---- Upload ---- */
 .upload {
@@ -68,6 +83,10 @@ header {
 .upload.dragover { border-color: var(--ink); background: #f1f1ec; }
 .upload strong { display: block; font-size: 18px; margin-bottom: 8px; }
 .upload .small { margin-top: 18px; margin-bottom: 0; }
+.upload-progress-head {
+  display: flex; align-items: center; justify-content: space-between; gap: 16px;
+}
+.upload-progress-head p { margin: 0; }
 .framing-choice {
   display: flex; justify-content: center; gap: 10px; margin: 24px auto 0;
   padding: 0; border: 0;
@@ -102,9 +121,9 @@ header {
   position: absolute; width: 1px; height: 1px; overflow: hidden;
   clip: rect(0 0 0 0); clip-path: inset(50%); white-space: nowrap;
 }
-.upload-swatches { display: flex; justify-content: center; gap: 9px; margin: 8px 0 5px; }
+.upload-swatches { display: flex; flex-wrap: wrap; justify-content: center; gap: 9px; margin: 8px 0 5px; }
 .upload-swatch {
-  width: 30px; height: 30px; padding: 0; border-radius: 50%;
+  width: 44px; height: 44px; padding: 0; border-radius: 50%;
   border: 2px solid #fff; background: var(--swatch);
   box-shadow: 0 0 0 1px rgba(29,29,27,.22); transition: transform .12s, box-shadow .12s;
 }
@@ -117,18 +136,19 @@ header {
 .accent-icon.random { background: conic-gradient(#ff4f4f, #ffdd00, #7cff4f, #4fb5ff, #c77dff, #ff4f4f); }
 .accent-icon.optimized { background: linear-gradient(135deg, #171717 50%, #ffdd00 50%); }
 .seg { display: inline-flex; border: 1px solid #8a8a84; border-radius: 6px; overflow: hidden; }
-.seg-btn { border: none; border-radius: 0; background: #fff; padding: 5px 11px; font-size: 12px; }
+.seg-btn { border: none; border-radius: 0; background: #fff; min-height: 44px; padding: 5px 11px; font-size: 13px; }
 .seg-btn + .seg-btn { border-left: 1px solid #8a8a84; }
 .seg-btn.active { background: var(--ink); color: #fff; }
 .swatches { display: inline-flex; align-items: center; gap: 6px; }
 .swatch {
-  width: 20px; height: 20px; border-radius: 50%; padding: 0;
+  width: 44px; height: 44px; border-radius: 50%; padding: 0;
   border: 2px solid transparent; box-shadow: inset 0 0 0 1px rgba(0,0,0,.15);
   cursor: pointer;
 }
 .swatch.active { border-color: var(--ink); }
+.custom-color-picker { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 12px; }
 .custom-color {
-  width: 22px; height: 22px; padding: 0; border: 1px dashed #8a8a84;
+  width: 44px; height: 44px; min-height: 44px; padding: 0; border: 1px dashed #8a8a84;
   border-radius: 50%; background: none; cursor: pointer;
 }
 .custom-color.active { border: 2px solid var(--ink); }
@@ -141,7 +161,16 @@ header {
   display: flex; justify-content: space-between; align-items: center;
   margin: 26px 0 18px;
 }
-.source-name { font-weight: 600; margin-right: 10px; }
+.source-line > div { min-width: 0; }
+.source-name {
+  display: inline-block; max-width: min(60vw, 560px); overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom;
+  font-weight: 600; margin-right: 10px;
+}
+.source-meta {
+  display: inline-block; max-width: 100%; overflow: hidden;
+  text-overflow: ellipsis; white-space: nowrap; vertical-align: bottom;
+}
 
 .progress {
   display: grid; grid-template-columns: repeat(7, 1fr); gap: 8px; margin: 0 0 22px;
@@ -172,6 +201,7 @@ header {
   background: #fdf6f5; padding: 13px 15px; border-radius: 4px; margin-top: 14px;
 }
 .error p { margin: 3px 0 0; font-size: 13px; }
+.error-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
 
 /* ---- Results ---- */
 .results-head {
@@ -181,13 +211,13 @@ header {
 .results-actions { display: flex; gap: 8px; }
 
 .clip {
-  display: grid; grid-template-columns: 156px minmax(0, 1fr) auto;
+  display: grid; grid-template-columns: 132px minmax(0, 1fr) auto;
   gap: 18px; align-items: center;
   border: 1px solid #b5b5ae; border-radius: 6px; background: var(--card);
   padding: 14px; margin-bottom: 12px;
 }
 .preview {
-  aspect-ratio: 9 / 16; width: 132px; margin: auto;
+  aspect-ratio: 9 / 16; width: 100%; max-width: 132px; margin: auto;
   background: #111; border-radius: 4px; overflow: hidden;
   display: grid; place-items: center; color: #888; font-size: 12px;
 }
@@ -196,11 +226,11 @@ header {
   font-size: 11.5px; color: var(--muted); letter-spacing: .07em;
   text-transform: uppercase; margin-bottom: 4px;
 }
-.clip h3 { font-size: 15.5px; margin: 0 0 6px; }
+.clip h3 { font-size: 16px; margin: 0 0 6px; overflow-wrap: anywhere; }
 .clip .times { font-size: 13px; margin: 0 0 8px; }
 .why {
   border-left: 3px solid #9a9a93; padding-left: 10px;
-  color: #55554f; font-size: 13px; margin: 0;
+  color: #55554f; font-size: 14px; margin: 0;
 }
 .badges { margin-top: 8px; display: flex; gap: 6px; flex-wrap: wrap; }
 .badge {
@@ -211,18 +241,18 @@ header {
 .badge.bad { border-color: #e2b6b2; color: var(--bad); }
 .actions { display: flex; flex-direction: column; gap: 8px; }
 .actions a { text-decoration: none; }
-.actions button { width: 100%; }
+.actions button, .actions a.action-button { width: 100%; }
 
 /* Per-clip caption restyling (style + accent color, applied post-render). */
 .restyle {
   display: flex; align-items: center; flex-wrap: wrap; gap: 10px;
   margin-top: 12px; padding-top: 10px; border-top: 1px dashed var(--hairline);
 }
-.restyle-label { letter-spacing: .07em; text-transform: uppercase; font-size: 11px; }
-.restyle button { padding: 5px 12px; font-size: 12.5px; }
+.restyle-label { flex-basis: 100%; letter-spacing: .07em; text-transform: uppercase; font-size: 12px; }
+.restyle button { padding: 5px 12px; font-size: 13px; }
 .restyle .seg-btn { padding: 5px 11px; }
 .font-select {
-  min-width: 130px; padding: 5px 28px 5px 8px; border: 0;
+  min-width: 130px; min-height: 44px; padding: 5px 28px 5px 8px; border: 0;
   border-radius: 4px; background: #fff; font-weight: 600;
 }
 .font-picker {
@@ -233,6 +263,9 @@ header {
   color: var(--muted); font-size: 10px; letter-spacing: .07em; text-transform: uppercase;
 }
 .restyle-status:empty { display: none; }
+.restyle-status.busy { color: var(--accent); }
+.restyle-status.success { color: var(--ok); }
+.restyle-status.status-error { color: var(--bad); }
 
 .empty-results {
   border: 1px dashed #9a9a93; border-radius: 6px; padding: 34px 24px;
@@ -257,40 +290,65 @@ footer { margin-top: 44px; border-top: 1px solid var(--hairline); padding-top: 1
 }
 .modal {
   width: min(440px, calc(100vw - 40px)); background: #fff; border-radius: 8px;
-  border: 1px solid var(--hairline); padding: 22px;
+  border: 1px solid var(--hairline); padding: 22px; max-height: calc(100vh - 32px);
+  max-height: calc(100dvh - 32px); overflow-y: auto;
 }
 .modal h3 { margin-bottom: 6px; }
 .modal label { display: block; margin: 14px 0 0; font-size: 13px; font-weight: 600; }
 .modal input, .modal select {
-  display: block; width: 100%; margin-top: 5px; padding: 8px 10px;
+  display: block; width: 100%; min-height: 44px; margin-top: 5px; padding: 8px 10px;
   border: 1px solid #8a8a84; border-radius: 5px; background: #fff; font-weight: 400;
 }
 .modal-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 20px; }
 #test-result.ok { color: var(--ok); }
 #test-result.bad { color: var(--bad); }
 
+body.modal-open { overflow: hidden; }
+
 @media (max-width: 860px) {
   .progress { grid-template-columns: repeat(4, 1fr); row-gap: 14px; }
 }
 @media (max-width: 720px) {
   .accent-choice { grid-template-columns: 1fr; }
-  .clip { grid-template-columns: 120px 1fr; }
+  .clip { grid-template-columns: minmax(104px, 132px) minmax(0, 1fr); }
   .actions { grid-column: 1 / -1; flex-direction: row; }
   .results-head { flex-direction: column; align-items: flex-start; }
+  .results-actions { flex-wrap: wrap; }
 }
 @media (max-width: 520px) {
   .shell { padding: 20px 16px 40px; }
   header { gap: 12px; flex-wrap: wrap; }
   #ai-btn { flex: none; }
+  .upload { margin: 22px 0; padding: 36px 16px; }
+  .upload-progress-head { align-items: flex-start; flex-direction: column; gap: 10px; }
   .framing-choice { flex-direction: column; align-items: stretch; }
   .framing-choice label { width: 100%; }
   .source-line { align-items: flex-start; gap: 10px; }
+  .source-name { max-width: 54vw; }
   .progress { grid-template-columns: repeat(2, 1fr); }
   .step strong { white-space: normal; }
   .results-actions { width: 100%; }
-  .results-actions button { flex: 1; padding-inline: 8px; }
+  .results-actions button { flex: 1; min-width: 140px; padding-inline: 8px; }
   .clip { grid-template-columns: 1fr; gap: 14px; padding: 16px; }
   .preview { width: min(180px, 100%); }
   .actions { grid-column: auto; }
-  .actions button { min-height: 44px; }
+  .actions { width: 100%; }
+  .actions a, .actions button { flex: 1; min-height: 44px; }
+  .error { align-items: stretch; flex-direction: column; }
+  .error-actions { justify-content: stretch; }
+  .error-actions button { flex: 1; }
+  .restyle { align-items: stretch; }
+  .restyle .seg, .restyle .swatches, .restyle .font-picker, .restyle .apply-captions { width: 100%; }
+  .restyle .seg-btn { flex: 1; }
+  .restyle .swatches { justify-content: flex-start; flex-wrap: wrap; }
+  .font-picker { justify-content: space-between; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## What changed

- made upload and pipeline cancellation truthful and reliable at every stage
- serialized project operations, added atomic artifact promotion, and preserved completed clips across retry/cancel
- rebuilt the studio states for upload, processing, failure, cancellation, empty results, partial results, and completed results
- added accessible caption style, color, and font controls with verified preview reloads
- hardened AI settings, MP4 range streaming, provider timeouts, UTF-8 headlines, selection heuristics, and overlap validation
- added a 1 GiB upload disk reserve, stronger eval provenance, and a product-polish roadmap

## Why

Clipping Factory needed to behave like a finished local product: a user must be able to stop unwanted work immediately, understand every state, preview and restyle clips confidently, and recover without corrupt or misleading outputs.

## Impact

The local studio is substantially safer and clearer while keeping its no-login, on-device workflow. `main` is unchanged; this draft is isolated to `codex/product-polish` for hands-on testing.

## Validation

- `cargo test --locked` — 95 passed
- `cargo clippy --all-targets --locked -- -D warnings`
- `cargo fmt --check`
- `cargo build --release --locked`
- `node --check static/app.js`
- `bash -n evals/run.sh`
- `CF_EVAL_TARGET_DIR=target bash evals/run.sh --fixtures`
- live desktop and 375px mobile QA
- live upload cancellation, mid-transcription cancellation, retry, full render/playback, caption restyle, and HTTP Range checks
