### PR TITLE
fix: map leading silence to file-wide RMS floor with -60 dBFS silence reference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+## Health Stack
+
+- typecheck: cargo check --all-targets
+- lint: cargo clippy --all-targets -- -D warnings
+- fmt: cargo fmt --all --check
+- test: cargo test
+- shell: bash -n evals/run.sh

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -65,6 +65,11 @@ pub async fn measure(
     Ok(EnergyProfile { per_second_db })
 }
 
+/// Fixed level for digital silence when the file has no quiet finite
+/// reference; `-inf` resolves to the quieter of this and the file-wide floor,
+/// keeping a contrast signal in silence-dominated files.
+const SILENCE_REFERENCE_DB: f32 = -60.0;
+
 /// Run ffmpeg capturing BOTH streams — `ametadata=print` writes to stderr on
 /// this ffmpeg build — while keeping cancellation control over the child.
 async fn run_astats_capture(
@@ -117,9 +122,14 @@ async fn run_astats_capture(
 /// ```
 ///
 /// and the older `frame:N|key:…RMS_level|value:-24.53` pipe format. `-inf`
-/// values (digital silence) and empty buckets map to the quietest level in the
-/// WHOLE file — computed in a second pass so leading silence cannot masquerade
-/// as a loud peak (a one-pass "quietest so far" floor starts at 0 dBFS).
+/// values (digital silence) and empty buckets map to the quieter of the
+/// file-wide floor and [`SILENCE_REFERENCE_DB`] — computed in a second pass so
+/// leading silence cannot masquerade as a loud peak (a one-pass "quietest so
+/// far" floor starts at 0 dBFS).
+///
+/// The fixed reference only bites when the file has no quiet finite level: a
+/// mostly-silent recording whose only sound is loud would otherwise resolve
+/// silence to that loud level and collapse to a flat profile.
 pub fn parse_rms_lines(output: &str) -> Vec<f32> {
     let mut samples: Vec<(f32, Option<f32>)> = Vec::new();
     let mut pending_sec: Option<f32> = None;
@@ -154,23 +164,23 @@ pub fn parse_rms_lines(output: &str) -> Vec<f32> {
     if samples.is_empty() {
         return Vec::new();
     }
-    // All-silence (or unreadable) input: no finite reference; keep the loudest
-    // possible level so the flat-audio guard in `window_boost` still applies.
-    if !floor.is_finite() {
-        floor = 0.0;
-    }
+    // Resolve silence to the quieter of the file-wide floor or the fixed
+    // reference. All-silence input falls out of the same expression
+    // (INFINITY.min(-60.0) = -60.0), yielding a flat profile that the
+    // flat-audio guard in `window_boost` neutralizes.
+    let silence_level = floor.min(SILENCE_REFERENCE_DB);
 
     let buckets = samples.iter().map(|(s, _)| *s as usize).max().unwrap_or(0) + 1;
     let mut acc: Vec<(f32, u32)> = vec![(0.0, 0); buckets];
     for (sec, v) in samples {
         let (sum, count) = &mut acc[sec as usize];
-        *sum += v.unwrap_or(floor);
+        *sum += v.unwrap_or(silence_level);
         *count += 1;
     }
     acc.into_iter()
         .map(|(sum, count)| {
             if count == 0 {
-                floor
+                silence_level
             } else {
                 sum / count as f32
             }
@@ -222,7 +232,7 @@ noise";
         assert_eq!(out.len(), 3);
         assert!((out[0] + 24.531234).abs() < 1e-4);
         assert!((out[1] + 18.0).abs() < 1e-4);
-        assert_eq!(out[2], out[0]); // -inf -> quietest observed
+        assert_eq!(out[2], SILENCE_REFERENCE_DB); // -inf -> quietest reference, quieter than any content
     }
 
     #[test]
@@ -236,7 +246,7 @@ noise";
     }
 
     #[test]
-    fn leading_silence_maps_to_the_file_floor_not_to_max_loudness() {
+    fn leading_silence_maps_to_a_quiet_reference_not_to_max_loudness() {
         // A recording that OPENS with digital silence must not look like a
         // 0 dBFS climax (one-pass "quietest so far" started at 0.0).
         let mut out = String::new();
@@ -255,21 +265,43 @@ noise";
         }
         let out = parse_rms_lines(&out);
         assert_eq!(out.len(), 6);
-        for v in &out {
+        for (i, v) in out.iter().enumerate() {
+            let expected = if i < 3 { SILENCE_REFERENCE_DB } else { -18.0 };
             assert!(
-                (v + 18.0).abs() < 1e-4,
-                "bucket should be the file floor -18, got {v}"
+                (v - expected).abs() < 1e-4,
+                "bucket {i} should be {expected}, got {v}"
             );
         }
         // The silent intro must NOT look loud relative to the file floor...
         let profile = EnergyProfile { per_second_db: out };
         assert_eq!(window_boost(&profile, 0, 3_000), 0.0);
         // ...while a genuinely loud stretch still gets its boost.
-        let mut db = vec![-18.0f32; 6];
-        db[3] = -6.0;
-        db[4] = -6.0;
-        let profile = EnergyProfile { per_second_db: db };
         assert!(window_boost(&profile, 3_000, 5_000) > 0.0);
+    }
+
+    #[test]
+    fn all_silence_stays_flat_and_never_boosts() {
+        // No finite RMS level anywhere: every bucket resolves to the fixed
+        // silence reference, giving a flat profile that the flat-audio guard
+        // in `window_boost` neutralizes.
+        let mut out = String::new();
+        for i in 0..4u32 {
+            let pts = i as f32 * 1.024;
+            out.push_str(&format!(
+                "[Parsed_ametadata_1 @ 0x0] frame:{i}    pts_time:{pts}\n"
+            ));
+            out.push_str("[Parsed_ametadata_1 @ 0x0] lavfi.astats.Overall.RMS_level=-inf\n");
+        }
+        let out = parse_rms_lines(&out);
+        assert_eq!(out.len(), 4);
+        for v in &out {
+            assert!(
+                (v - SILENCE_REFERENCE_DB).abs() < 1e-4,
+                "bucket should be the silence reference, got {v}"
+            );
+        }
+        let profile = EnergyProfile { per_second_db: out };
+        assert_eq!(window_boost(&profile, 0, 4_000), 0.0);
     }
 
     #[test]

--- a/src/energy.rs
+++ b/src/energy.rs
@@ -116,15 +116,15 @@ async fn run_astats_capture(
 /// [Parsed_ametadata_1 @ 0x…] lavfi.astats.Overall.RMS_level=-21.087600
 /// ```
 ///
-/// and the older `frame:N|key:…RMS_level|value:-24.53` pipe format. Missing or
-/// `-inf` values (digital silence) map to the quietest observed level; empty
-/// buckets stay at that floor.
+/// and the older `frame:N|key:…RMS_level|value:-24.53` pipe format. `-inf`
+/// values (digital silence) and empty buckets map to the quietest level in the
+/// WHOLE file — computed in a second pass so leading silence cannot masquerade
+/// as a loud peak (a one-pass "quietest so far" floor starts at 0 dBFS).
 pub fn parse_rms_lines(output: &str) -> Vec<f32> {
-    let mut samples: Vec<(f32, f32)> = Vec::new();
+    let mut samples: Vec<(f32, Option<f32>)> = Vec::new();
     let mut pending_sec: Option<f32> = None;
-    // Quietest finite level observed so far; starts at 0 dBFS (the loudest
-    // possible) and descends as real samples arrive.
-    let mut floor = 0.0f32;
+    // Quietest finite level anywhere in the file.
+    let mut floor = f32::INFINITY;
 
     for line in output.lines() {
         if let Some(sec) = line
@@ -142,25 +142,29 @@ pub fn parse_rms_lines(output: &str) -> Vec<f32> {
             .and_then(|s| s.trim().parse::<f32>().ok());
         if let Some(v) = value {
             if v.is_finite() {
-                if v < floor {
-                    floor = v;
-                }
-                samples.push((pending_sec.unwrap_or(samples.len() as f32), v));
+                floor = floor.min(v);
+                samples.push((pending_sec.unwrap_or(samples.len() as f32), Some(v)));
             } else {
-                // `-inf` (digital silence) -> quietest level observed so far.
-                samples.push((pending_sec.unwrap_or(samples.len() as f32), floor));
+                // `-inf` (digital silence) -> resolved to the file-wide floor
+                // in the second pass below.
+                samples.push((pending_sec.unwrap_or(samples.len() as f32), None));
             }
         }
     }
     if samples.is_empty() {
         return Vec::new();
     }
+    // All-silence (or unreadable) input: no finite reference; keep the loudest
+    // possible level so the flat-audio guard in `window_boost` still applies.
+    if !floor.is_finite() {
+        floor = 0.0;
+    }
 
     let buckets = samples.iter().map(|(s, _)| *s as usize).max().unwrap_or(0) + 1;
     let mut acc: Vec<(f32, u32)> = vec![(0.0, 0); buckets];
     for (sec, v) in samples {
         let (sum, count) = &mut acc[sec as usize];
-        *sum += v;
+        *sum += v.unwrap_or(floor);
         *count += 1;
     }
     acc.into_iter()
@@ -229,6 +233,43 @@ noise";
         );
         assert_eq!(out.len(), 2);
         assert!((out[1] + 20.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn leading_silence_maps_to_the_file_floor_not_to_max_loudness() {
+        // A recording that OPENS with digital silence must not look like a
+        // 0 dBFS climax (one-pass "quietest so far" started at 0.0).
+        let mut out = String::new();
+        for i in 0..6u32 {
+            let pts = i as f32 * 1.024;
+            out.push_str(&format!(
+                "[Parsed_ametadata_1 @ 0x0] frame:{i}    pts_time:{pts}\n"
+            ));
+            if i < 3 {
+                out.push_str("[Parsed_ametadata_1 @ 0x0] lavfi.astats.Overall.RMS_level=-inf\n");
+            } else {
+                out.push_str(
+                    "[Parsed_ametadata_1 @ 0x0] lavfi.astats.Overall.RMS_level=-18.000000\n",
+                );
+            }
+        }
+        let out = parse_rms_lines(&out);
+        assert_eq!(out.len(), 6);
+        for v in &out {
+            assert!(
+                (v + 18.0).abs() < 1e-4,
+                "bucket should be the file floor -18, got {v}"
+            );
+        }
+        // The silent intro must NOT look loud relative to the file floor...
+        let profile = EnergyProfile { per_second_db: out };
+        assert_eq!(window_boost(&profile, 0, 3_000), 0.0);
+        // ...while a genuinely loud stretch still gets its boost.
+        let mut db = vec![-18.0f32; 6];
+        db[3] = -6.0;
+        db[4] = -6.0;
+        let profile = EnergyProfile { per_second_db: db };
+        assert!(window_boost(&profile, 3_000, 5_000) > 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the energy-profile floor logic that made recordings opening with digital silence look like a 0 dBFS climax, and adds a fixed silence reference so silence-dominated files keep their loudness contrast.

**Energy scoring fix** (`src/energy.rs`)
- `parse_rms_lines` now resolves `-inf` (digital silence) in a second pass against the quietest finite level in the whole file, instead of a one-pass "quietest so far" floor that started at 0 dBFS — leading silence can no longer masquerade as a loud peak.
- Digital silence now resolves to the quieter of the file-wide floor and a fixed `SILENCE_REFERENCE_DB` (-60 dBFS), so a mostly-silent file whose only sound is loud no longer collapses to a flat profile where no window gets a boost.
- New tests: `leading_silence_maps_to_a_quiet_reference_not_to_max_loudness` (end-to-end through the parser), `all_silence_stays_flat_and_never_boosts`; updated `parses_real_ffmpeg_format_and_buckets_by_second` to the new contract.

**Docs**
- New `AGENTS.md` with the project's health stack (cargo check / clippy / fmt / test, bash -n), persisted from the /health run.

## Test Coverage

All new code paths have test coverage:

```
CODE PATHS — src/energy.rs (parse_rms_lines changed)
[+] parse_rms_lines()
  ├── 1. pts_time parse OK → pending_sec set          [★★★ parses_real_ffmpeg_format_and_buckets_by_second]
  ├── 2. pts_time parse FAIL → fallback               [★★  parses_legacy_pipe_format]
  ├── 3. RMS parse OK via "RMS_level="                [★★★ SAMPLE + leading-silence + all-silence tests]
  ├── 4. RMS parse OK via legacy "value:" pipe        [★★★ parses_legacy_pipe_format]
  ├── 5. RMS parse FAIL → line skipped                [★★  SAMPLE trailing "noise" line]
  ├── 6. finite value → floor = floor.min(v)          [★★★ all fixtures]
  ├── 7. -inf → None, resolved to silence reference   [★★★ leading-silence + all-silence tests]
  └── 8. all-silence → flat profile, boost 0          [★★★ all_silence_stays_flat_and_never_boosts]
[+] window_boost guards (len<2, std<1.0, hi<=lo, z<0)
      [★★★ flat_audio_and_tiny_profiles_never_boost + loud_window_gets_boost_quiet_window_gets_zero]
```

Tests: 110 → 111 (+1 new; 1 renamed/strengthened).

## Pre-Landing Review

2 informational findings, both fixed:
- Testing (9/10): all-silence fallback branch untested → branch removed (subsumed by `SILENCE_REFERENCE_DB`), replaced by an explicit all-silence test.
- Adversarial (7/10): silence-dominated files collapsed to a flat profile (no boost anywhere) → `SILENCE_REFERENCE_DB` fixed reference + end-to-end parser assertion that the loud stretch keeps its boost.

Adversarial synthesis: Claude structured ✓ (clean) · Claude adversarial ✓ (1 finding, fixed) · Codex ✓ (no findings). Codex structured skipped (diff < 200 lines).

## Design Review

No frontend files changed — design review skipped.

## Eval Results

No prompt-related files changed — evals skipped.

## Scope Drift

Scope Check: CLEAN — intent (energy floor fix + health stack docs) matches the diff exactly.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Verification Results

- cargo fmt --all --check: CLEAN
- cargo clippy --all-targets -- -D warnings: CLEAN (0 warnings)
- cargo test: 111 passed, 0 failed
- bash -n evals/run.sh: OK
- python3 -m py_compile evals/report.py: OK

## Test plan

- [x] cargo test — 111/111 pass
- [x] cargo fmt --all --check — clean
- [x] cargo clippy --all-targets -- -D warnings — clean
- [x] bash -n evals/run.sh — clean
