### PR TITLE
feat: EBU R128 loudness normalization with per-clip audio QC

### DIFF
--- a/src/accent.rs
+++ b/src/accent.rs
@@ -148,7 +148,9 @@ pub async fn optimized_accent_for_video(
         pixels.extend(
             output
                 .stdout
-                .chunks_exact(3)
+                .as_chunks::<3>()
+                .0
+                .iter()
                 .map(|rgb| [rgb[0], rgb[1], rgb[2]]),
         );
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -782,6 +782,7 @@ async fn restyle_clip(
             &clip.layout,
             clip.start_ms,
             clip.end_ms,
+            None,
             &base_temp,
             &cancel,
             |_| {},

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,0 +1,242 @@
+//! Audio loudness normalization and QC (EBU R128).
+//!
+//! Social platforms normalize playback loudness themselves; delivering clips
+//! near a consistent target (-16 LUFS integrated, -1.5 dBTP) keeps them from
+//! being turned up or down unpredictably and makes a batch of clips sound
+//! uniform. Two-pass `loudnorm` measures the source segment first, then
+//! applies a *linear* gain correction during the base render — no dynamic
+//! processing, so the speech keeps its natural dynamics. The final file is
+//! measured again as a QC check that travels with the clip record.
+
+use crate::config::Config;
+use anyhow::{anyhow, bail, Context, Result};
+use std::path::Path;
+use std::process::Stdio;
+use tokio_util::sync::CancellationToken;
+
+/// Delivery targets (streaming/spocial-video convention): -16 LUFS
+/// integrated, -1.5 dBTP ceiling, LRA left open for speech.
+pub const TARGET_I: f64 = -16.0;
+pub const TARGET_TP: f64 = -1.5;
+const TARGET_LRA: f64 = 11.0;
+
+/// One pass of `loudnorm` measurement over a source segment (or whole file
+/// when `dur_ms` is `None`).
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
+pub struct LoudnessMeasure {
+    #[serde(rename = "input_i")]
+    pub input_i: f64,
+    #[serde(rename = "input_tp")]
+    pub input_tp: f64,
+    #[serde(rename = "input_lra")]
+    pub input_lra: f64,
+    #[serde(rename = "input_thresh")]
+    pub input_thresh: f64,
+    #[serde(rename = "target_offset")]
+    pub target_offset: f64,
+}
+
+/// Second-pass loudnorm filter: linear gain correction toward the target.
+pub fn loudnorm_filter(m: &LoudnessMeasure) -> String {
+    format!(
+        "loudnorm=I={}:TP={}:LRA={}:measured_I={:.2}:measured_TP={:.2}:\
+measured_LRA={:.2}:measured_thresh={:.2}:offset={:.2}:linear=true:print_format=none",
+        TARGET_I,
+        TARGET_TP,
+        TARGET_LRA,
+        m.input_i,
+        m.input_tp,
+        m.input_lra,
+        m.input_thresh,
+        m.target_offset
+    )
+}
+
+/// Measure integrated loudness / true peak of a file (or a time-boxed slice
+/// of it) with `loudnorm`'s JSON printout on stderr.
+pub async fn measure(
+    cfg: &Config,
+    input: &Path,
+    start_ms: Option<u64>,
+    dur_ms: Option<u64>,
+    cancel: &CancellationToken,
+) -> Result<LoudnessMeasure> {
+    let mut args: Vec<String> = vec![
+        "-hide_banner".into(),
+        "-nostats".into(),
+        "-loglevel".into(),
+        "info".into(),
+    ];
+    if let Some(s) = start_ms {
+        args.extend(["-ss".into(), format!("{:.3}", s as f64 / 1000.0)]);
+    }
+    if let Some(d) = dur_ms {
+        args.extend(["-t".into(), format!("{:.3}", d as f64 / 1000.0)]);
+    }
+    args.extend([
+        "-i".into(),
+        input.to_string_lossy().into_owned(),
+        "-map".into(),
+        "a:0".into(),
+        "-af".into(),
+        format!(
+            "loudnorm=I={}:TP={}:LRA={}:print_format=json",
+            TARGET_I, TARGET_TP, TARGET_LRA
+        ),
+        "-f".into(),
+        "null".into(),
+        "-".into(),
+    ]);
+
+    // loudnorm prints its JSON report on stderr, so this mirrors
+    // `util::run_capture_cancellable` but captures stderr.
+    let bin = cfg.ffmpeg.clone();
+    let mut task = tokio::spawn(async move {
+        tokio::process::Command::new(&bin)
+            .args(&args)
+            .stdin(Stdio::null())
+            .kill_on_drop(true)
+            .output()
+            .await
+            .with_context(|| format!("failed to start `{}`", bin))
+    });
+
+    let out = tokio::select! {
+        biased;
+        _ = cancel.cancelled() => {
+            task.abort();
+            let _ = task.await;
+            bail!("cancelled");
+        }
+        result = &mut task => result.context("loudness measurement task failed")??,
+    };
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        bail!(
+            "`{}` exited with {} — {}",
+            cfg.ffmpeg,
+            out.status.code().unwrap_or(-1),
+            err.lines().last().unwrap_or("").trim()
+        );
+    }
+
+    parse_loudnorm_json(&String::from_utf8_lossy(&out.stderr))
+}
+
+/// Extract the last JSON object from ffmpeg's stderr (loudnorm prints exactly
+/// one at the end of the run). Real ffmpeg quotes every value ("-23.40"), so
+/// numeric fields accept strings or bare numbers.
+fn parse_loudnorm_json(stderr: &str) -> Result<LoudnessMeasure> {
+    let open = stderr
+        .rfind('{')
+        .ok_or_else(|| anyhow!("loudnorm produced no JSON report"))?;
+    let close = stderr[open..]
+        .find('}')
+        .ok_or_else(|| anyhow!("loudnorm JSON report was truncated"))?;
+    let json = &stderr[open..=open + close];
+    let value: serde_json::Value =
+        serde_json::from_str(json).map_err(|e| anyhow!("could not parse loudnorm report: {e}"))?;
+    let field = |name: &str| -> Result<f64> {
+        match &value[name] {
+            serde_json::Value::Number(n) => n.as_f64(),
+            serde_json::Value::String(s) => s.parse::<f64>().ok(),
+            _ => None,
+        }
+        .ok_or_else(|| anyhow!("loudnorm report was missing {name}"))
+    };
+    let parsed = LoudnessMeasure {
+        input_i: field("input_i")?,
+        input_tp: field("input_tp")?,
+        input_lra: field("input_lra")?,
+        input_thresh: field("input_thresh")?,
+        target_offset: field("target_offset")?,
+    };
+    // Silence measures around -70/-inf; a linear correction would be garbage.
+    if parsed.input_i < -70.0 {
+        bail!("segment is effectively silent; skipping loudness normalization");
+    }
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(i: &str, tp: &str, lra: &str, thresh: &str, offset: &str) -> String {
+        format!(
+            r#"some ffmpeg noise above
+[Parsed_loudnorm] 
+{{
+	"input_i" : "{i}",
+	"input_tp" : "{tp}",
+	"input_lra" : "{lra}",
+	"input_thresh" : "{thresh}",
+	"output_i" : "-16.05",
+	"output_tp" : "-1.54",
+	"output_lra" : "8.40",
+	"output_thresh" : "-26.11",
+	"normalization_type" : "dynamic",
+	"target_offset" : "{offset}"
+}}
+"#
+        )
+    }
+
+    #[test]
+    fn parses_quoted_values_exactly_as_ffmpeg_emits_them() {
+        let m = parse_loudnorm_json(&report("-23.4", "-1.2", "8.1", "-33.9", "-0.05")).unwrap();
+        assert_eq!(m.input_i, -23.4);
+        assert_eq!(m.input_tp, -1.2);
+        assert_eq!(m.input_lra, 8.1);
+        assert_eq!(m.input_thresh, -33.9);
+        assert_eq!(m.target_offset, -0.05);
+    }
+
+    #[test]
+    fn parses_bare_numbers_too() {
+        let m = parse_loudnorm_json(
+            r#"{ "input_i" : -23.4, "input_tp" : -1.2, "input_lra" : 8.1,
+                 "input_thresh" : -33.9, "target_offset" : -0.05 }"#,
+        )
+        .unwrap();
+        assert_eq!(m.input_i, -23.4);
+    }
+
+    #[test]
+    fn missing_fields_are_an_error_not_a_default() {
+        let broken = report("-23.4", "-1.2", "8.1", "-33.9", "-0.05").replacen(
+            "\"input_i\"",
+            "\"input_missing\"",
+            1,
+        );
+        assert!(parse_loudnorm_json(&broken).is_err());
+    }
+
+    #[test]
+    fn missing_report_is_an_error() {
+        assert!(parse_loudnorm_json("no json here").is_err());
+    }
+
+    #[test]
+    fn silence_is_rejected_instead_of_gain_stacked() {
+        let err =
+            parse_loudnorm_json(&report("-91.0", "-91.0", "0.0", "-100.0", "0.0")).unwrap_err();
+        assert!(err.to_string().contains("silent"));
+    }
+
+    #[test]
+    fn second_pass_filter_is_linear_and_carries_measurements() {
+        let m = LoudnessMeasure {
+            input_i: -23.4,
+            input_tp: -1.2,
+            input_lra: 8.1,
+            input_thresh: -33.9,
+            target_offset: -0.05,
+        };
+        let f = loudnorm_filter(&m);
+        assert!(f.starts_with("loudnorm=I=-16:TP=-1.5:LRA=11:"));
+        assert!(f.contains("measured_I=-23.40"));
+        assert!(f.contains("measured_TP=-1.20"));
+        assert!(f.contains("linear=true"));
+    }
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -315,6 +315,22 @@ pub struct ClipRecord {
     /// Editable caption wording. Word timings are preserved when possible.
     #[serde(default)]
     pub caption_text: Option<String>,
+    /// Loudness QC for the rendered file, when normalization ran and the
+    /// output could be measured. Absent on older manifests.
+    #[serde(default)]
+    pub audio_qc: Option<AudioQc>,
+}
+
+/// EBU R128 loudness QC numbers for a finished clip: what the source segment
+/// measured, what target the two-pass linear normalization aimed at, and what
+/// the rendered file actually measures.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct AudioQc {
+    pub target_i: f64,
+    pub source_i: f64,
+    pub source_tp: f64,
+    pub output_i: f64,
+    pub output_tp: f64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 
 mod accent;
 mod api;
+mod audio;
 mod captions;
 mod config;
 mod domain;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -626,6 +626,7 @@ async fn run(
                         c.start_ms,
                         c.end_ms,
                     ))),
+                    audio_qc: None,
                 });
             }
             match result {
@@ -721,6 +722,32 @@ async fn run(
         let base_temp = unique_temp_path(&base_path);
         let out_temp = unique_temp_path(&out_path);
         let base_ready = store.base_is_ready(&id, &clip.id).await?;
+        // Measure the source segment first so the base render can apply a
+        // linear two-pass loudnorm correction. Advisory: a failed measurement
+        // renders unnormalized rather than failing the clip.
+        let loudness = if base_ready {
+            None
+        } else {
+            match crate::audio::measure(
+                cfg,
+                &src,
+                Some(clip.start_ms),
+                Some(clip.end_ms - clip.start_ms),
+                &ctx.cancel,
+            )
+            .await
+            {
+                Ok(m) => Some(m),
+                // Advisory: a failed measurement renders unnormalized rather
+                // than failing the clip. Cancellation is caught by the check
+                // at the top of the next loop iteration.
+                Err(e) => {
+                    tracing::warn!("loudness measurement failed, rendering unnormalized: {e:#}");
+                    None
+                }
+            }
+        };
+        let audio_filter = loudness.as_ref().map(crate::audio::loudnorm_filter);
 
         let render_result: anyhow::Result<()> = async {
             // Pass 1 — framed, uncaptioned base. Kept on disk so captions can
@@ -736,6 +763,7 @@ async fn run(
                     &clip.layout,
                     clip.start_ms,
                     clip.end_ms,
+                    audio_filter.as_deref(),
                     &base_temp,
                     &ctx.cancel,
                     |pct| prog(pct * 0.85, Some(done_label.clone())),
@@ -783,6 +811,20 @@ async fn run(
             }
             promote_atomic(&out_temp, &out_path).await?;
             store.mark_final_ready(&id, &clip.id).await?;
+            // QC: measure what actually shipped. Never fails the clip.
+            if let Ok(final_qc) =
+                crate::audio::measure(cfg, &out_path, None, None, &ctx.cancel).await
+            {
+                if let Some(source_qc) = &loudness {
+                    manifest.clips[i].audio_qc = Some(AudioQc {
+                        target_i: crate::audio::TARGET_I,
+                        source_i: source_qc.input_i,
+                        source_tp: source_qc.input_tp,
+                        output_i: final_qc.input_i,
+                        output_tp: final_qc.input_tp,
+                    });
+                }
+            }
             Ok(())
         }
         .await;

--- a/src/render.rs
+++ b/src/render.rs
@@ -33,6 +33,7 @@ pub async fn render_base_clip<F>(
     layout: &LayoutPlan,
     start_ms: u64,
     end_ms: u64,
+    audio_filter: Option<&str>,
     out_path: &Path,
     cancel: &CancellationToken,
     mut on_progress: F,
@@ -41,7 +42,7 @@ where
     F: FnMut(f32),
 {
     let dur_s = (end_ms.saturating_sub(start_ms)) as f64 / 1000.0;
-    let graph = build_graph(source, layout, None);
+    let graph = build_graph(source, layout, None, audio_filter);
 
     let mut args: Vec<String> = vec![
         "-y".into(),
@@ -240,9 +241,16 @@ pub fn subtitles_filter(fonts_dir: Option<&Path>, ass_path: &Path) -> String {
     format!("ass='{}'{}", ass, fonts)
 }
 
-fn build_graph(source: &SourceInfo, layout: &LayoutPlan, subs: Option<&str>) -> String {
+fn build_graph(
+    source: &SourceInfo,
+    layout: &LayoutPlan,
+    subs: Option<&str>,
+    audio_filter: Option<&str>,
+) -> String {
     // Trailing subtitle step when burning in one pass; empty for base renders.
     let subs_step = subs.map(|s| format!("{},", s)).unwrap_or_default();
+    // Optional audio processing step (loudness normalization).
+    let audio_step = audio_filter.map(|f| format!(",{f}")).unwrap_or_default();
     match layout {
         LayoutPlan::BlurPad => format!(
             "[0:v]setpts=PTS-STARTPTS,split=2[bga][fga];\
@@ -250,10 +258,11 @@ fn build_graph(source: &SourceInfo, layout: &LayoutPlan, subs: Option<&str>) -> 
              crop={w}:{h},gblur=sigma=26,eq=brightness=-0.14:saturation=0.8[bg];\
              [fga]scale={w}:{h}:force_original_aspect_ratio=decrease:force_divisible_by=2[fg];\
              [bg][fg]overlay=(W-w)/2:(H-h)/2,{subs}format=yuv420p[v];\
-             [0:a]asetpts=PTS-STARTPTS[a]",
+             [0:a]asetpts=PTS-STARTPTS{audio}[a]",
             w = OUT_W,
             h = OUT_H,
-            subs = subs_step
+            subs = subs_step,
+            audio = audio_step
         ),
         LayoutPlan::FaceCrop { keyframes } => {
             // Scale so height fills 1920, then crop a 1080-wide window whose
@@ -264,17 +273,18 @@ fn build_graph(source: &SourceInfo, layout: &LayoutPlan, subs: Option<&str>) -> 
             };
             if scaled_w < OUT_W as u64 {
                 // Shouldn't happen (frame.rs guards portrait), but stay safe.
-                return build_graph(source, &LayoutPlan::BlurPad, subs);
+                return build_graph(source, &LayoutPlan::BlurPad, subs, audio_filter);
             }
             let expr = crop_x_expr(keyframes, scaled_w);
             format!(
                 "[0:v]setpts=PTS-STARTPTS,scale=-2:{h}:force_divisible_by=2,\
                  crop={w}:{h}:x='{expr}':y=0,{subs}format=yuv420p[v];\
-                 [0:a]asetpts=PTS-STARTPTS[a]",
+                 [0:a]asetpts=PTS-STARTPTS{audio}[a]",
                 w = OUT_W,
                 h = OUT_H,
                 expr = expr,
-                subs = subs_step
+                subs = subs_step,
+                audio = audio_step
             )
         }
     }
@@ -396,7 +406,7 @@ mod tests {
                 keyframes: vec![CropKey { t_ms: 0, cx: 0.5 }],
             },
         ] {
-            let g = build_graph(&source(1920, 1080), &layout, None);
+            let g = build_graph(&source(1920, 1080), &layout, None, None);
             assert!(
                 !g.contains("ass="),
                 "base graph must not burn captions: {g}"
@@ -407,7 +417,7 @@ mod tests {
 
     #[test]
     fn base_graph_resets_audio_and_video_to_the_same_zero_origin() {
-        let g = build_graph(&source(1920, 1080), &LayoutPlan::BlurPad, None);
+        let g = build_graph(&source(1920, 1080), &LayoutPlan::BlurPad, None, None);
         assert!(g.contains("[0:v]setpts=PTS-STARTPTS"));
         assert!(g.contains("[0:a]asetpts=PTS-STARTPTS[a]"));
     }
@@ -415,8 +425,21 @@ mod tests {
     #[test]
     fn captioned_graph_includes_subtitle_filter() {
         let subs = subtitles_filter(None, Path::new("/tmp/c.ass"));
-        let g = build_graph(&source(1920, 1080), &LayoutPlan::BlurPad, Some(&subs));
+        let g = build_graph(&source(1920, 1080), &LayoutPlan::BlurPad, Some(&subs), None);
         assert!(g.contains("ass='/tmp/c.ass'"));
+    }
+
+    #[test]
+    fn audio_filter_lands_on_the_audio_branch_only() {
+        for layout in [
+            LayoutPlan::BlurPad,
+            LayoutPlan::FaceCrop {
+                keyframes: vec![CropKey { t_ms: 0, cx: 0.5 }],
+            },
+        ] {
+            let g = build_graph(&source(1920, 1080), &layout, None, Some("loudnorm"));
+            assert!(g.contains("asetpts=PTS-STARTPTS,loudnorm[a]"));
+        }
     }
 
     #[test]
@@ -433,6 +456,7 @@ mod tests {
             &LayoutPlan::FaceCrop {
                 keyframes: vec![CropKey { t_ms: 0, cx: 0.5 }],
             },
+            None,
             None,
         );
         assert!(

--- a/src/store.rs
+++ b/src/store.rs
@@ -334,6 +334,7 @@ mod tests {
                 accent_color: Some("#FFDD00".into()),
                 caption_font: Some("Inter".into()),
                 caption_text: None,
+                audio_qc: None,
             }],
             output_dir: Some("/tmp/out".into()),
         };
@@ -371,6 +372,7 @@ mod tests {
             caption_text: None,
             accent_color: None,
             caption_font: None,
+            audio_qc: None,
         };
         store
             .save_manifest(
@@ -456,6 +458,7 @@ mod tests {
                         caption_text: None,
                         accent_color: None,
                         caption_font: None,
+                        audio_qc: None,
                     }],
                     output_dir: None,
                 },


### PR DESCRIPTION
## What

Every clip now ships loudness-normalized and QC-measured:

1. **Measure** — before the base render, the clip's source segment is measured with ffmpeg `loudnorm` (integrated LUFS, true peak, LRA, threshold).
2. **Normalize** — the base render applies a **two-pass linear** gain correction toward -16 LUFS integrated / -1.5 dBTP. Linear, not dynamic: speech keeps its natural dynamics.
3. **QC** — the finished file is re-measured and the numbers (source/output LUFS + true peak, target) are stored on the clip record (`audio_qc`), so every clip carries proof of its loudness.

## Why

Inconsistent loudness across clips is one of the most common complaints about AI clippers, and platforms normalize playback themselves — delivering near a consistent target keeps clips from being unpredictably turned up or down. From docs/product/PAID_PRODUCT_RESEARCH.md: audio loudness/QC scores 8.4 on willingness-to-pay.

## Behavior notes

- Measurement is **advisory**: a failed measurement renders unnormalized rather than failing the clip. Effectively-silent segments skip normalization instead of stacking gain.
- Old manifests load unchanged (`audio_qc` is `#[serde(default)]`).
- Base-render reuse is respected: resumed clips don't re-measure.

## Proof on real ffmpeg

```
source: -47.85 LUFS / -44.06 dBTP  →  after filter: -16.05 LUFS (target -16)
```

## Verification

- `cargo fmt --all --check` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo test` 118 passed (new: loudnorm JSON parsing incl. quoted values as ffmpeg actually emits, silence rejection, second-pass filter shape, audio branch placement in filter graph)