### PR TITLE
feat: provenance & QC report for every delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +198,7 @@ dependencies = [
  "rustface",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -204,6 +214,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -238,6 +257,26 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -416,6 +455,16 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1380,6 +1429,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1773,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 rustface = "0.1"
+sha2 = "0.10"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
 
 [profile.release]

--- a/src/accent.rs
+++ b/src/accent.rs
@@ -148,7 +148,9 @@ pub async fn optimized_accent_for_video(
         pixels.extend(
             output
                 .stdout
-                .chunks_exact(3)
+                .as_chunks::<3>()
+                .0
+                .iter()
                 .map(|rgb| [rgb[0], rgb[1], rgb[2]]),
         );
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -10,6 +10,7 @@
 //! POST   /api/projects/{id}/process  start/resume
 //! POST   /api/projects/{id}/cancel   stop subprocesses, keep finished clips
 //! POST   /api/projects/{id}/retry    re-run failed stage / failed clips only
+//! GET    /api/projects/{id}/provenance.json  provenance & QC report (attachment)
 //! GET    /api/projects/{id}/clips/{clipId}           inline MP4 (Range-aware)
 //! GET    /api/projects/{id}/clips/{clipId}/download  attachment
 //! POST   /api/projects/{id}/clips/{clipId}/restyle   re-burn captions (style/color)
@@ -17,6 +18,7 @@
 
 use crate::domain::*;
 use crate::pipeline;
+use crate::provenance;
 use crate::settings::AiSettings;
 use crate::state::AppState;
 use axum::extract::{DefaultBodyLimit, Multipart, Path as AxPath, State};
@@ -56,6 +58,7 @@ pub fn router(state: AppState) -> Router {
             "/api/projects/{id}/clips/{clip}/restyle",
             post(restyle_clip),
         )
+        .route("/api/projects/{id}/provenance.json", get(provenance_report))
         .route(
             "/api/projects/{id}/open-output-folder",
             post(open_output_folder),
@@ -579,6 +582,35 @@ async fn retry_project(
 // ---------------------------------------------------------------------------
 // SSE
 // ---------------------------------------------------------------------------
+
+async fn provenance_report(
+    State(state): State<AppState>,
+    AxPath(id): AxPath<String>,
+) -> Result<Response, ApiError> {
+    if !state.store.exists(&id) {
+        return Err(not_found("Project not found."));
+    }
+    let project = state.store.load_project(&id).await?;
+    let manifest = state.store.load_manifest(&id).await.ok();
+    let selection = state.store.load_selection(&id).await.ok();
+    let report = provenance::gather(
+        &state.cfg,
+        &state.store,
+        &project,
+        manifest.as_ref(),
+        selection.as_ref(),
+    )
+    .await;
+    let body = serde_json::to_vec_pretty(&report).map_err(anyhow::Error::from)?;
+    Ok(Response::builder()
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"provenance-{id}.json\""),
+        )
+        .body(axum::body::Body::from(body))
+        .map_err(anyhow::Error::from)?)
+}
 
 async fn project_events(
     State(state): State<AppState>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod energy;
 mod frame;
 mod media;
 mod pipeline;
+mod provenance;
 mod render;
 mod select;
 mod settings;

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -876,6 +876,13 @@ async fn run(
         p.status = JobState::Complete;
         p.error = None;
         store.save_project(&p).await?;
+        // Best-effort provenance sidecar next to the delivered clips. Must
+        // never fail the render: all errors are logged inside.
+        let selection = store.load_selection(&id).await;
+        let prov =
+            crate::provenance::gather(cfg, store, &p, Some(&manifest), selection.as_ref().ok())
+                .await;
+        crate::provenance::write_sidecar(&prov, &output_dir).await;
         ctx.handle
             .emit(json!({"type": "done", "status": "complete"}));
     } else {

--- a/src/provenance.rs
+++ b/src/provenance.rs
@@ -1,0 +1,359 @@
+//! Provenance & QC reporting: machine-checkable proof that a delivery's
+//! clips are faithful excerpts of a named source, produced by named tools.
+//!
+//! Every field that cannot be established locally is serialized as `null` —
+//! a provenance report must never fabricate a value. The same report is
+//! served from `GET /api/projects/{id}/provenance.json` and written as a
+//! `provenance.json` sidecar next to the delivered clips after a successful
+//! render. Sidecar failures are logged, never fatal: provenance must not
+//! break rendering.
+
+use crate::config::Config;
+use crate::domain::{Project, RenderManifest, SelectionReport};
+use crate::store::Store;
+use anyhow::Result;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::Path;
+use tokio::io::AsyncReadExt;
+
+/// Streaming SHA-256 of a file, hex-encoded lowercase. Safe for multi-GB
+/// sources: the file is read in fixed chunks, never held in memory.
+pub async fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = tokio::fs::File::open(path).await?;
+    let mut hasher = Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).await?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Tool identities recorded in the report. `None` means "could not be
+/// established", not "not used".
+#[derive(Serialize, Clone, Debug, Default)]
+pub struct ToolsInfo {
+    /// First line of `ffmpeg -version`.
+    pub ffmpeg_version: Option<String>,
+    /// File name of the ggml model used for transcription.
+    pub whisper_model: Option<String>,
+}
+
+/// SHA-256 of each rendered clip MP4, keyed by clip id. Ready clips only.
+pub struct ClipHashes(pub HashMap<String, String>);
+
+#[derive(Serialize, Clone, Debug)]
+struct SourceProvenance {
+    filename: Option<String>,
+    size_bytes: Option<u64>,
+    duration_ms: Option<u64>,
+    source_sha256: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+struct SelectionSummary {
+    selector: Option<String>,
+    accepted: Option<usize>,
+    rejected: Option<usize>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+struct ClipProvenance {
+    rank: usize,
+    headline: String,
+    filename: String,
+    start_ms: u64,
+    end_ms: u64,
+    duration_ms: u64,
+    layout: &'static str,
+    caption_style: Option<String>,
+    accent_color: Option<String>,
+    sha256: Option<String>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct ProvenanceReport {
+    generated_at: String,
+    project_id: String,
+    source: SourceProvenance,
+    tools: ToolsInfo,
+    selection: SelectionSummary,
+    clips: Vec<ClipProvenance>,
+}
+
+/// Assemble the report from persisted project state. Pure aside from reading
+/// nothing: all expensive work (hashing, tool probing) happens in [`gather`],
+/// so this is directly unit-testable without real media.
+pub fn build_report(
+    project: &Project,
+    manifest: Option<&RenderManifest>,
+    selection: Option<&SelectionReport>,
+    source_sha256: Option<String>,
+    tools: ToolsInfo,
+    hashes: &ClipHashes,
+) -> ProvenanceReport {
+    let source = match &project.source {
+        Some(s) => SourceProvenance {
+            filename: Some(s.filename.clone()),
+            size_bytes: Some(s.size_bytes),
+            duration_ms: Some(s.duration_ms),
+            source_sha256,
+        },
+        None => SourceProvenance {
+            filename: None,
+            size_bytes: None,
+            duration_ms: None,
+            source_sha256: None,
+        },
+    };
+    let selection = match selection {
+        Some(r) => SelectionSummary {
+            selector: Some(r.selector.clone()),
+            accepted: Some(r.accepted.len()),
+            rejected: Some(r.rejected.len()),
+        },
+        None => SelectionSummary {
+            selector: project.selector.clone(),
+            accepted: None,
+            rejected: None,
+        },
+    };
+    let mut clips: Vec<ClipProvenance> = manifest
+        .map(|m| {
+            m.clips
+                .iter()
+                .map(|c| ClipProvenance {
+                    rank: c.rank,
+                    headline: c.headline.clone(),
+                    filename: c.filename.clone(),
+                    start_ms: c.start_ms,
+                    end_ms: c.end_ms,
+                    duration_ms: c.duration_ms,
+                    layout: c.layout.label(),
+                    caption_style: c.caption_style.clone(),
+                    accent_color: c.accent_color.clone(),
+                    sha256: hashes.0.get(&c.id).cloned(),
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    clips.sort_by_key(|c| c.rank);
+    ProvenanceReport {
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        project_id: project.id.clone(),
+        source,
+        tools,
+        selection,
+        clips,
+    }
+}
+
+/// Hash every ready clip and probe tool versions, then assemble the report.
+/// All probing is best-effort: unavailable facts become `null`s.
+pub async fn gather(
+    cfg: &Config,
+    store: &Store,
+    project: &Project,
+    manifest: Option<&RenderManifest>,
+    selection: Option<&SelectionReport>,
+) -> ProvenanceReport {
+    let source_sha256 = sha256_file(&store.source_path(&project.id)).await.ok();
+    let ffmpeg_version = crate::util::run_capture(&cfg.ffmpeg, &["-version".into()])
+        .await
+        .ok()
+        .and_then(|out| out.lines().next().map(str::to_string));
+    let whisper_model = cfg.whisper_model.as_ref().map(|p| {
+        p.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned()
+    });
+    let tools = ToolsInfo {
+        ffmpeg_version,
+        whisper_model,
+    };
+
+    let mut by_clip_id = HashMap::new();
+    if let Some(m) = manifest {
+        for clip in m
+            .clips
+            .iter()
+            .filter(|c| c.status == crate::domain::ClipStatus::Ready)
+        {
+            let path = store.clips_dir(&project.id).join(&clip.filename);
+            if let Ok(hash) = sha256_file(&path).await {
+                by_clip_id.insert(clip.id.clone(), hash);
+            }
+        }
+    }
+
+    build_report(
+        project,
+        manifest,
+        selection,
+        source_sha256,
+        tools,
+        &ClipHashes(by_clip_id),
+    )
+}
+
+/// Write the report as `provenance.json` inside `dir` (the delivered output
+/// folder). Best-effort: failures are logged and swallowed.
+pub async fn write_sidecar(report: &ProvenanceReport, dir: &Path) {
+    let body = match serde_json::to_vec_pretty(report) {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!("provenance sidecar serialization failed: {e}");
+            return;
+        }
+    };
+    if let Err(e) = crate::util::atomic_write_bytes(&dir.join("provenance.json"), &body).await {
+        tracing::warn!("provenance sidecar write failed: {e:#}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{
+        Candidate, ClipRecord, ClipStatus, LayoutPlan, Scores, ValidatedCandidate,
+    };
+
+    fn test_project() -> Project {
+        Project::new("prov-test".into(), "/tmp/source.mp4".into())
+    }
+
+    fn test_clip(id: &str, rank: usize, layout: LayoutPlan) -> ClipRecord {
+        ClipRecord {
+            id: id.into(),
+            rank,
+            headline: format!("Clip {rank}"),
+            filename: format!("{rank:02}-clip.mp4"),
+            start_ms: 1_000,
+            end_ms: 31_000,
+            duration_ms: 30_000,
+            selection_reason: "strong moment".into(),
+            scores: Scores::default(),
+            layout,
+            status: ClipStatus::Ready,
+            error: None,
+            low_confidence: false,
+            caption_style: Some("impact".into()),
+            accent_color: Some("#FF5500".into()),
+            caption_font: None,
+            caption_text: None,
+        }
+    }
+
+    fn test_manifest(clips: Vec<ClipRecord>) -> RenderManifest {
+        RenderManifest {
+            clips,
+            output_dir: None,
+        }
+    }
+
+    fn test_candidate() -> Candidate {
+        Candidate {
+            start_ms: 0,
+            end_ms: 1,
+            headline: "h".into(),
+            opening_quote: String::new(),
+            closing_quote: String::new(),
+            selection_reason: String::new(),
+            scores: Scores::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn sha256_matches_known_vector() {
+        let path = std::env::temp_dir().join(format!("cf-prov-{}", crate::util::short_id()));
+        tokio::fs::write(&path, b"abc").await.unwrap();
+        let hash = sha256_file(&path).await.unwrap();
+        tokio::fs::remove_file(&path).await.ok();
+        assert_eq!(
+            hash,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_pieces_serialize_as_null() {
+        let project = test_project();
+        let report = build_report(
+            &project,
+            None,
+            None,
+            None,
+            ToolsInfo::default(),
+            &ClipHashes(HashMap::new()),
+        );
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["source"]["filename"], serde_json::Value::Null);
+        assert_eq!(v["source"]["source_sha256"], serde_json::Value::Null);
+        assert_eq!(v["tools"]["ffmpeg_version"], serde_json::Value::Null);
+        assert_eq!(v["selection"]["accepted"], serde_json::Value::Null);
+        assert_eq!(v["clips"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn clips_are_ordered_by_rank_with_layout_and_hash_passthrough() {
+        let mut project = test_project();
+        project.source = Some(crate::domain::SourceInfo {
+            filename: "show.mp4".into(),
+            duration_ms: 600_000,
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            video_codec: "h264".into(),
+            audio_codec: "aac".into(),
+            size_bytes: 123,
+        });
+        let manifest = test_manifest(vec![
+            test_clip("b", 2, LayoutPlan::BlurPad),
+            test_clip("a", 1, LayoutPlan::FaceCrop { keyframes: vec![] }),
+        ]);
+        let selection = SelectionReport {
+            selector: "offline heuristic".into(),
+            accepted: vec![ValidatedCandidate {
+                candidate: test_candidate(),
+                rank: 1,
+                composite: 0.8,
+                duration_exception: false,
+            }],
+            rejected: Vec::new(),
+        };
+        let mut hashes = HashMap::new();
+        hashes.insert("a".to_string(), "hash-a".to_string());
+        let report = build_report(
+            &project,
+            Some(&manifest),
+            Some(&selection),
+            Some("hash-src".into()),
+            ToolsInfo {
+                ffmpeg_version: Some("ffmpeg v7".into()),
+                whisper_model: Some("ggml-base.en.bin".into()),
+            },
+            &ClipHashes(hashes),
+        );
+        let v = serde_json::to_value(&report).unwrap();
+        assert_eq!(v["source"]["filename"], "show.mp4");
+        assert_eq!(v["source"]["source_sha256"], "hash-src");
+        assert_eq!(v["selection"]["selector"], "offline heuristic");
+        assert_eq!(v["selection"]["accepted"], 1);
+        assert_eq!(v["selection"]["rejected"], 0);
+        let clips = v["clips"].as_array().unwrap();
+        assert_eq!(clips.len(), 2);
+        assert_eq!(clips[0]["rank"], 1);
+        assert_eq!(clips[1]["rank"], 2);
+        assert_eq!(clips[0]["layout"], "face_crop");
+        assert_eq!(clips[1]["layout"], "blur_pad");
+        assert_eq!(clips[0]["sha256"], "hash-a");
+        assert_eq!(clips[1]["sha256"], serde_json::Value::Null);
+        assert_eq!(clips[0]["caption_style"], "impact");
+    }
+}


### PR DESCRIPTION
## What

Every project can now produce a provenance report proving its clips are faithful excerpts of a named source, produced by named tools:

- `GET /api/projects/{id}/provenance.json` — on-demand report (attachment): source filename + SHA-256, duration, ffmpeg version, whisper model, selector used, accepted/rejected counts, and per-clip rank/headline/boundaries/layout/caption treatment/SHA-256 of the rendered MP4. Missing facts serialize as `null` — never fabricated defaults.
- After a successful render, the same report is written as `provenance.json` next to the delivered clips in the output folder (best-effort; provenance must never break rendering).

## Why

Agencies and privacy-sensitive users want proof with their deliveries. From docs/product/PAID_PRODUCT_RESEARCH.md: provenance/audit scores 8.7 on willingness-to-pay — 'agencies treat proof as part of delivery'.

## Verification

- `cargo fmt --all --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` 114 passed
- SHA-256 tested against the known `abc` vector; report builder tested for null handling, layout labels, and rank ordering.
- No frontend changes.