### PR TITLE
feat(api): project library — list and delete past projects

### DIFF
--- a/src/accent.rs
+++ b/src/accent.rs
@@ -148,7 +148,9 @@ pub async fn optimized_accent_for_video(
         pixels.extend(
             output
                 .stdout
-                .chunks_exact(3)
+                .as_chunks::<3>()
+                .0
+                .iter()
                 .map(|rgb| [rgb[0], rgb[1], rgb[2]]),
         );
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,7 @@
 //! HTTP API (PRD §14.1) + the studio's static assets.
 //!
+//! GET    /api/projects               project library (most recent first)
+//! DELETE /api/projects/{id}          remove a project's local data
 //! POST   /api/settings/ai            set provider/model/key
 //! GET    /api/settings/ai            public status (never the key)
 //! POST   /api/settings/ai/test       verify connectivity
@@ -25,6 +27,7 @@ use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
+use chrono::{DateTime, Utc};
 use futures::stream::{self, Stream, StreamExt};
 use serde_json::json;
 use std::convert::Infallible;
@@ -41,8 +44,11 @@ pub fn router(state: AppState) -> Router {
         .route("/api/setup", get(setup_status))
         .route("/api/settings/ai", get(get_settings).post(set_settings))
         .route("/api/settings/ai/test", post(test_settings))
-        .route("/api/projects", post(create_project))
-        .route("/api/projects/{id}", get(get_project))
+        .route("/api/projects", post(create_project).get(list_projects))
+        .route(
+            "/api/projects/{id}",
+            get(get_project).delete(delete_project),
+        )
         .route("/api/projects/{id}/events", get(project_events))
         .route("/api/projects/{id}/process", post(process_project))
         .route("/api/projects/{id}/cancel", post(cancel_project))
@@ -577,6 +583,95 @@ async fn retry_project(
 }
 
 // ---------------------------------------------------------------------------
+// Project library: reopen past work, remove finished projects
+// ---------------------------------------------------------------------------
+
+/// One row of the project library: enough to identify and reopen past work.
+#[derive(serde::Serialize)]
+struct LibraryEntry {
+    id: String,
+    created_at: DateTime<Utc>,
+    status: JobState,
+    source_filename: Option<String>,
+    width: Option<u32>,
+    height: Option<u32>,
+    duration_ms: Option<u64>,
+    clips_total: usize,
+    clips_ready: usize,
+    clips_failed: usize,
+}
+
+/// Scan the projects root into library rows. Corrupt or foreign directories
+/// are skipped (with a warning), never surfaced as errors — one bad project
+/// must not hide the rest of the archive.
+async fn library_entries(store: &crate::store::Store) -> Vec<LibraryEntry> {
+    let mut entries = Vec::new();
+    for id in store.project_ids().await {
+        let Ok(p) = store.load_project(&id).await else {
+            tracing::warn!(project = %id, "skipping unloadable project in library scan");
+            continue;
+        };
+        let manifest = store.load_manifest(&id).await.ok();
+        entries.push(LibraryEntry {
+            clips_total: manifest.as_ref().map(|m| m.clips.len()).unwrap_or(0),
+            clips_ready: manifest
+                .as_ref()
+                .map(|m| {
+                    m.clips
+                        .iter()
+                        .filter(|c| c.status == ClipStatus::Ready)
+                        .count()
+                })
+                .unwrap_or(0),
+            clips_failed: manifest
+                .as_ref()
+                .map(|m| {
+                    m.clips
+                        .iter()
+                        .filter(|c| c.status == ClipStatus::Failed)
+                        .count()
+                })
+                .unwrap_or(0),
+            id: p.id,
+            created_at: p.created_at,
+            status: p.status,
+            source_filename: p.source.as_ref().map(|s| s.filename.clone()),
+            width: p.source.as_ref().map(|s| s.width),
+            height: p.source.as_ref().map(|s| s.height),
+            duration_ms: p.source.as_ref().map(|s| s.duration_ms),
+        });
+    }
+    entries.sort_by_key(|e| std::cmp::Reverse(e.created_at));
+    entries.truncate(100);
+    entries
+}
+
+async fn list_projects(State(state): State<AppState>) -> Json<serde_json::Value> {
+    Json(json!(library_entries(&state.store).await))
+}
+
+async fn delete_project(
+    State(state): State<AppState>,
+    AxPath(id): AxPath<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    if !state.store.exists(&id) {
+        return Err(not_found("Project not found."));
+    }
+    if state.handle(&id).is_running() {
+        return Err(ApiError(
+            StatusCode::CONFLICT,
+            "Processing is running for this project. Cancel it before deleting.".into(),
+        ));
+    }
+    // Only the working directory under data_dir is removed; rendered clips
+    // already copied to the user-facing output folder stay untouched.
+    tokio::fs::remove_dir_all(state.store.project_dir(&id))
+        .await
+        .map_err(|e| ApiError::from(anyhow::Error::new(e)))?;
+    Ok(Json(json!({ "deleted": true })))
+}
+
+// ---------------------------------------------------------------------------
 // SSE
 // ---------------------------------------------------------------------------
 
@@ -1044,6 +1139,59 @@ mod tests {
     use axum::body::{Body, Bytes};
     use axum::extract::FromRequest;
     use axum::http::Request;
+
+    fn temp_store(tag: &str) -> (PathBuf, crate::store::Store) {
+        let tmp = std::env::temp_dir().join(format!("cf-lib-{}-{}", tag, crate::util::short_id()));
+        let store = crate::store::Store::new(&tmp);
+        (tmp, store)
+    }
+
+    #[tokio::test]
+    async fn library_scan_of_an_empty_root_is_empty() {
+        let (tmp, store) = temp_store("empty");
+        tokio::fs::create_dir_all(&tmp).await.unwrap();
+        assert!(library_entries(&store).await.is_empty());
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn library_scan_skips_corrupt_projects_and_sorts_newest_first() {
+        let (tmp, store) = temp_store("mixed");
+        // Newest project.
+        store.create_dirs("proj-new").await.unwrap();
+        let mut newer = Project::new("proj-new".into(), store.source_path("proj-new"));
+        newer.created_at = Utc::now();
+        store.save_project(&newer).await.unwrap();
+        // Older project, created a day earlier.
+        store.create_dirs("proj-old").await.unwrap();
+        let mut older = Project::new("proj-old".into(), store.source_path("proj-old"));
+        older.created_at = Utc::now() - chrono::Duration::days(1);
+        older.source = Some(SourceInfo {
+            filename: "episode.mp4".into(),
+            duration_ms: 60_000,
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            video_codec: "h264".into(),
+            audio_codec: "aac".into(),
+            size_bytes: 1,
+        });
+        store.save_project(&older).await.unwrap();
+        // Corrupt entry must be skipped, not fatal.
+        store.create_dirs("proj-bad").await.unwrap();
+        tokio::fs::write(store.project_json("proj-bad"), b"{ not json")
+            .await
+            .unwrap();
+
+        let entries = library_entries(&store).await;
+
+        assert_eq!(entries.len(), 2, "corrupt project must be skipped");
+        assert_eq!(entries[0].id, "proj-new", "newest first");
+        assert_eq!(entries[1].id, "proj-old");
+        assert_eq!(entries[1].source_filename.as_deref(), Some("episode.mp4"));
+        assert_eq!(entries[1].clips_total, 0);
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
 
     #[test]
     fn byte_ranges_support_open_ended_and_suffix_requests() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -90,6 +90,21 @@ impl Store {
         self.project_json(id).is_file()
     }
 
+    /// Directory names under the projects root. Callers decide which entries
+    /// are loadable projects; corrupt or foreign directories are not an error.
+    pub async fn project_ids(&self) -> Vec<String> {
+        let mut ids = Vec::new();
+        let Ok(mut entries) = tokio::fs::read_dir(&self.root).await else {
+            return ids;
+        };
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            if entry.metadata().await.map(|m| m.is_dir()).unwrap_or(false) {
+                ids.push(entry.file_name().to_string_lossy().into_owned());
+            }
+        }
+        ids
+    }
+
     pub async fn create_dirs(&self, id: &str) -> Result<()> {
         tokio::fs::create_dir_all(self.base_dir(id)).await?;
         Ok(())


### PR DESCRIPTION
## What

The browser used to remember exactly one project; finished work was unreachable. Two endpoints fix that:

- `GET /api/projects` (method-chained with the existing upload POST) — project library, most recent first, capped at 100: id, created_at, status, source filename/dimensions/duration, and clip counts (total/ready/failed). Corrupt or foreign directories are skipped with a warning — one bad project never hides the archive.
- `DELETE /api/projects/{id}` — removes only the project's working directory under data_dir; user-facing output folders are untouched. Refuses with 409 while processing is active, 404 when missing.

## Why

'Recent-project inbox/history with explicit cleanup' is the first deferred item in TODOS.md; returning users need their back catalog.

## Verification

- `cargo fmt --all --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ · `cargo test` 113 passed
- Library scan tested against a temp dir: empty → [], good + corrupt projects → only good returned, ordering enforced.
- No frontend changes.