### PR TITLE
feat: persist review decisions and export kept clips as one ZIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +206,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zip",
 ]
 
 [[package]]
@@ -238,6 +248,17 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "dirs"
@@ -285,6 +306,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -455,6 +482,12 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "http"
@@ -701,6 +734,16 @@ dependencies = [
  "png",
  "zune-core",
  "zune-jpeg",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -2219,10 +2262,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 rustface = "0.1"
 image = { version = "0.25", default-features = false, features = ["jpeg", "png"] }
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [profile.release]
 opt-level = 2

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,13 +13,16 @@
 //! GET    /api/projects/{id}/clips/{clipId}           inline MP4 (Range-aware)
 //! GET    /api/projects/{id}/clips/{clipId}/download  attachment
 //! POST   /api/projects/{id}/clips/{clipId}/restyle   re-burn captions (style/color)
+//! GET    /api/projects/{id}/decisions                review triage map
+//! PUT    /api/projects/{id}/decisions                replace the triage map
+//! GET    /api/projects/{id}/export?verdicts=kept     ZIP of clips matching verdicts
 //! POST   /api/projects/{id}/open-output-folder
 
 use crate::domain::*;
 use crate::pipeline;
 use crate::settings::AiSettings;
 use crate::state::AppState;
-use axum::extract::{DefaultBodyLimit, Multipart, Path as AxPath, State};
+use axum::extract::{DefaultBodyLimit, Multipart, Path as AxPath, Query, State};
 use axum::http::{header, HeaderMap, StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
@@ -56,6 +59,11 @@ pub fn router(state: AppState) -> Router {
             "/api/projects/{id}/clips/{clip}/restyle",
             post(restyle_clip),
         )
+        .route(
+            "/api/projects/{id}/decisions",
+            get(get_decisions).put(put_decisions),
+        )
+        .route("/api/projects/{id}/export", get(export_clips))
         .route(
             "/api/projects/{id}/open-output-folder",
             post(open_output_folder),
@@ -870,6 +878,145 @@ async fn restyle_clip(
 }
 
 // ---------------------------------------------------------------------------
+// Review decisions + batch export
+// ---------------------------------------------------------------------------
+
+async fn require_project(state: &AppState, id: &str) -> Result<(), ApiError> {
+    if state.store.exists(id) {
+        Ok(())
+    } else {
+        Err(not_found("Project not found."))
+    }
+}
+
+async fn get_decisions(
+    State(state): State<AppState>,
+    AxPath(id): AxPath<String>,
+) -> Result<Json<ReviewDecisions>, ApiError> {
+    require_project(&state, &id).await?;
+    Ok(Json(state.store.load_decisions(&id).await?))
+}
+
+/// Full-map replace. Keys must be this project's canonical clip paths; the
+/// verdict enum is enforced by deserialization, so unknown verdicts never
+/// reach this handler.
+async fn put_decisions(
+    State(state): State<AppState>,
+    AxPath(id): AxPath<String>,
+    Json(body): Json<ReviewDecisions>,
+) -> Result<Json<ReviewDecisions>, ApiError> {
+    require_project(&state, &id).await?;
+    let prefix = format!("/api/projects/{id}/clips/");
+    if let Some(key) = body.decisions.keys().find(|k| !k.starts_with(&prefix)) {
+        return Err(bad_request(format!(
+            "decision key `{key}` does not belong to project {id}"
+        )));
+    }
+    state.store.save_decisions(&id, &body).await?;
+    Ok(Json(body))
+}
+
+#[derive(serde::Deserialize)]
+struct ExportQuery {
+    verdicts: Option<String>,
+}
+
+fn build_zip(zip_path: &std::path::Path, entries: &[(String, PathBuf)]) -> anyhow::Result<()> {
+    let file = std::fs::File::create(zip_path)?;
+    let mut zip = zip::ZipWriter::new(file);
+    let opts = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+    for (name, path) in entries {
+        zip.start_file(name.as_str(), opts)?;
+        std::io::copy(&mut std::fs::File::open(path)?, &mut zip)?;
+    }
+    zip.finish()?;
+    Ok(())
+}
+
+async fn export_clips(
+    State(state): State<AppState>,
+    AxPath(id): AxPath<String>,
+    Query(query): Query<ExportQuery>,
+) -> Result<Response, ApiError> {
+    let filter = match &query.verdicts {
+        None => vec![ReviewVerdict::Kept],
+        Some(spec) => ReviewVerdict::parse_list(spec).ok_or_else(|| {
+            bad_request("verdicts must be a comma-separated list of kept|maybe|skipped")
+        })?,
+    };
+    require_project(&state, &id).await?;
+    let manifest = state
+        .store
+        .load_manifest(&id)
+        .await
+        .map_err(|_| not_found("No rendered clips for this project yet."))?;
+    let decisions = state.store.load_decisions(&id).await?;
+
+    let mut selected: Vec<(String, PathBuf)> = Vec::new();
+    for clip in &manifest.clips {
+        if clip.status != ClipStatus::Ready {
+            continue;
+        }
+        let path = state.store.clips_dir(&id).join(&clip.filename);
+        let on_disk = tokio::fs::metadata(&path)
+            .await
+            .map(|m| m.is_file() && m.len() > 0)
+            .unwrap_or(false);
+        if !on_disk {
+            continue;
+        }
+        let Some(entry) = decisions.decisions.get(&clip_decision_key(&id, &clip.id)) else {
+            continue;
+        };
+        if filter.contains(&entry.verdict) {
+            selected.push((clip.filename.clone(), path));
+        }
+    }
+    if selected.is_empty() {
+        return Err(not_found("No clips match this verdict filter."));
+    }
+
+    let tag = filter
+        .iter()
+        .map(|v| format!("{v:?}").to_lowercase())
+        .collect::<Vec<_>>()
+        .join("-");
+    let zip_path = state
+        .store
+        .project_dir(&id)
+        .join(format!(".export-{tag}.zip"));
+    tokio::task::spawn_blocking(move || build_zip(&zip_path, &selected))
+        .await
+        .map_err(|e| ApiError(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))??;
+
+    let file = tokio::fs::File::open(
+        state
+            .store
+            .project_dir(&id)
+            .join(format!(".export-{tag}.zip")),
+    )
+    .await
+    .map_err(|e| ApiError::from(anyhow::Error::from(e)))?;
+    let len = file
+        .metadata()
+        .await
+        .map_err(|e| ApiError::from(anyhow::Error::from(e)))?
+        .len();
+    Response::builder()
+        .header(header::CONTENT_TYPE, "application/zip")
+        .header(header::CONTENT_LENGTH, len.to_string())
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"clips-{tag}.zip\""),
+        )
+        .body(axum::body::Body::from_stream(
+            tokio_util::io::ReaderStream::new(file),
+        ))
+        .map_err(|e| ApiError::from(anyhow::Error::from(e)))
+}
+
+// ---------------------------------------------------------------------------
 // Clip serving (Range-aware so <video> scrubbing works, esp. Safari)
 // ---------------------------------------------------------------------------
 
@@ -1128,6 +1275,175 @@ mod tests {
             .is_err());
         let mut projects = tokio::fs::read_dir(projects_dir).await.unwrap();
         assert!(projects.next_entry().await.unwrap().is_none());
+        tokio::fs::remove_dir_all(tmp).await.ok();
+    }
+
+    #[test]
+    fn verdict_filters_parse_strictly() {
+        assert_eq!(
+            ReviewVerdict::parse_list("kept, maybe"),
+            Some(vec![ReviewVerdict::Kept, ReviewVerdict::Maybe])
+        );
+        assert_eq!(ReviewVerdict::parse_list("kept,bogus"), None);
+    }
+
+    fn decision(verdict: ReviewVerdict) -> DecisionEntry {
+        DecisionEntry {
+            verdict,
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    async fn export_fixture_state(tag: &str) -> (AppState, String) {
+        let tmp = std::env::temp_dir().join(format!("cf-export-{tag}-{}", crate::util::short_id()));
+        let mut cfg = crate::config::Config::resolve();
+        cfg.data_dir = tmp.join("data");
+        cfg.output_root = tmp.join("output");
+        let state = AppState::new(cfg);
+        let id = "exportproj1";
+        state.store.create_dirs(id).await.unwrap();
+        state
+            .store
+            .save_project(&Project::new(id.to_string(), state.store.source_path(id)))
+            .await
+            .unwrap();
+
+        let clip = |cid: &str, name: &str| ClipRecord {
+            id: cid.into(),
+            rank: 1,
+            headline: "H".into(),
+            filename: name.into(),
+            start_ms: 0,
+            end_ms: 20_000,
+            duration_ms: 20_000,
+            selection_reason: "test".into(),
+            scores: Scores::default(),
+            layout: LayoutPlan::BlurPad,
+            status: ClipStatus::Ready,
+            error: None,
+            low_confidence: false,
+            caption_style: None,
+            caption_text: None,
+            accent_color: None,
+            caption_font: None,
+        };
+        state
+            .store
+            .save_manifest(
+                id,
+                &RenderManifest {
+                    clips: vec![clip("keepme", "01-keep.mp4"), clip("skipme", "02-skip.mp4")],
+                    output_dir: None,
+                },
+            )
+            .await
+            .unwrap();
+        tokio::fs::write(state.store.clips_dir(id).join("01-keep.mp4"), b"kept-bytes")
+            .await
+            .unwrap();
+        tokio::fs::write(
+            state.store.clips_dir(id).join("02-skip.mp4"),
+            b"skipped-bytes",
+        )
+        .await
+        .unwrap();
+        let mut d = ReviewDecisions::default();
+        d.decisions.insert(
+            clip_decision_key(id, "keepme"),
+            decision(ReviewVerdict::Kept),
+        );
+        d.decisions.insert(
+            clip_decision_key(id, "skipme"),
+            decision(ReviewVerdict::Skipped),
+        );
+        state.store.save_decisions(id, &d).await.unwrap();
+        (state, tmp.to_string_lossy().into_owned())
+    }
+
+    #[tokio::test]
+    async fn decisions_roundtrip_rejects_foreign_keys_and_unknown_projects() {
+        let (state, tmp) = export_fixture_state("api-decisions").await;
+        let id = "exportproj1";
+
+        let got = match get_decisions(State(state.clone()), AxPath(id.to_string())).await {
+            Ok(got) => got,
+            Err(e) => panic!("decisions should load: {:?}", e.0),
+        };
+        assert_eq!(got.decisions.len(), 2);
+
+        let mut foreign = ReviewDecisions::default();
+        foreign.decisions.insert(
+            "/api/projects/other/clips/c1".into(),
+            decision(ReviewVerdict::Kept),
+        );
+        let err = match put_decisions(State(state.clone()), AxPath(id.to_string()), Json(foreign))
+            .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("foreign decision key should be rejected"),
+        };
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+
+        let missing = match get_decisions(State(state.clone()), AxPath("nope".into())).await {
+            Err(e) => e,
+            Ok(_) => panic!("unknown project should 404"),
+        };
+        assert_eq!(missing.0, StatusCode::NOT_FOUND);
+
+        tokio::fs::remove_dir_all(tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn export_zips_only_clips_matching_the_verdict_filter() {
+        let (state, tmp) = export_fixture_state("api-export").await;
+        let id = "exportproj1";
+
+        let response = match export_clips(
+            State(state.clone()),
+            AxPath(id.to_string()),
+            Query(ExportQuery { verdicts: None }),
+        )
+        .await
+        {
+            Ok(response) => response,
+            Err(e) => panic!("kept export should succeed: {:?}", e.0),
+        };
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CONTENT_TYPE], "application/zip");
+        let body = axum::body::to_bytes(response.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        let reader = zip::ZipArchive::new(std::io::Cursor::new(&body[..])).unwrap();
+        assert_eq!(reader.file_names().collect::<Vec<_>>(), vec!["01-keep.mp4"]);
+
+        let empty = match export_clips(
+            State(state.clone()),
+            AxPath(id.to_string()),
+            Query(ExportQuery {
+                verdicts: Some("maybe".into()),
+            }),
+        )
+        .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("empty filter result should 404"),
+        };
+        assert_eq!(empty.0, StatusCode::NOT_FOUND);
+
+        let bad = match export_clips(
+            State(state.clone()),
+            AxPath(id.to_string()),
+            Query(ExportQuery {
+                verdicts: Some("nope".into()),
+            }),
+        )
+        .await
+        {
+            Err(e) => e,
+            Ok(_) => panic!("invalid verdict token should be rejected"),
+        };
+        assert_eq!(bad.0, StatusCode::BAD_REQUEST);
+
         tokio::fs::remove_dir_all(tmp).await.ok();
     }
 }

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// Ordered pipeline stages, matching PRD §14.2.
@@ -89,6 +90,49 @@ pub struct SourceInfo {
     pub video_codec: String,
     pub audio_codec: String,
     pub size_bytes: u64,
+}
+
+/// Operator triage verdict for one rendered clip, persisted server-side so
+/// review decisions survive the browser and can drive batch export.
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum ReviewVerdict {
+    Kept,
+    Maybe,
+    Skipped,
+}
+
+impl ReviewVerdict {
+    /// Parse the comma-separated `verdicts` export filter. None on any
+    /// unknown token so bad queries fail at the boundary.
+    pub fn parse_list(spec: &str) -> Option<Vec<ReviewVerdict>> {
+        spec.split(',')
+            .map(|s| match s.trim() {
+                "kept" => Some(ReviewVerdict::Kept),
+                "maybe" => Some(ReviewVerdict::Maybe),
+                "skipped" => Some(ReviewVerdict::Skipped),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+/// Canonical decisions-map key for a clip: its inline-serving URL path.
+#[must_use]
+pub fn clip_decision_key(project_id: &str, clip_id: &str) -> String {
+    format!("/api/projects/{project_id}/clips/{clip_id}")
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct DecisionEntry {
+    pub verdict: ReviewVerdict,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+pub struct ReviewDecisions {
+    #[serde(default)]
+    pub decisions: HashMap<String, DecisionEntry>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -65,6 +65,22 @@ impl Store {
     pub fn manifest_path(&self, id: &str) -> PathBuf {
         self.project_dir(id).join("render-manifest.json")
     }
+    pub fn decisions_path(&self, id: &str) -> PathBuf {
+        self.project_dir(id).join("decisions.json")
+    }
+
+    /// Missing file means no triage yet, which is a valid empty state.
+    pub async fn load_decisions(&self, id: &str) -> Result<ReviewDecisions> {
+        match tokio::fs::read(self.decisions_path(id)).await {
+            Ok(bytes) => Ok(serde_json::from_slice(&bytes)?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(ReviewDecisions::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub async fn save_decisions(&self, id: &str, d: &ReviewDecisions) -> Result<()> {
+        atomic_write_json(&self.decisions_path(id), d).await
+    }
     pub fn clips_dir(&self, id: &str) -> PathBuf {
         self.project_dir(id).join("clips")
     }
@@ -304,6 +320,42 @@ mod tests {
         assert_eq!(loaded.status, JobState::Transcribing);
         assert_eq!(loaded.stages.len(), STAGES.len());
         assert_eq!(loaded.stage_mut("transcribing").progress, Some(0.42));
+
+        tokio::fs::remove_dir_all(&tmp).await.ok();
+    }
+
+    #[tokio::test]
+    async fn decisions_roundtrip_and_default_when_missing() {
+        let tmp = std::env::temp_dir().join(format!("cf-decisions-{}", crate::util::short_id()));
+        let store = Store::new(&tmp);
+        let id = "decisions01";
+        store.create_dirs(id).await.unwrap();
+
+        assert_eq!(store.load_decisions(id).await.unwrap().decisions.len(), 0);
+
+        let mut d = ReviewDecisions::default();
+        d.decisions.insert(
+            clip_decision_key(id, "c1"),
+            DecisionEntry {
+                verdict: ReviewVerdict::Kept,
+                updated_at: chrono::Utc::now(),
+            },
+        );
+        d.decisions.insert(
+            clip_decision_key(id, "c2"),
+            DecisionEntry {
+                verdict: ReviewVerdict::Skipped,
+                updated_at: chrono::Utc::now(),
+            },
+        );
+        store.save_decisions(id, &d).await.unwrap();
+
+        let loaded = store.load_decisions(id).await.unwrap();
+        assert_eq!(loaded.decisions.len(), 2);
+        assert_eq!(
+            loaded.decisions[&clip_decision_key(id, "c1")].verdict,
+            ReviewVerdict::Kept
+        );
 
         tokio::fs::remove_dir_all(&tmp).await.ok();
     }

--- a/static/index.html
+++ b/static/index.html
@@ -114,6 +114,7 @@
           <p class="muted" id="results-sub">Ranked by self-contained opening, tension, payoff, and clarity.</p>
         </div>
         <div class="results-actions">
+          <button id="export-kept-btn" type="button" hidden>Download kept</button>
           <button id="review-clips-btn" type="button" hidden>Review clips</button>
           <button id="open-folder-btn" type="button">Open output folder</button>
           <button id="new-project-btn" type="button">New project</button>

--- a/static/review.js
+++ b/static/review.js
@@ -5,6 +5,7 @@
   const root = document.getElementById("clips");
   const results = document.getElementById("results-state");
   const openBtn = document.getElementById("review-clips-btn");
+  const exportBtn = document.getElementById("export-kept-btn");
   const theater = document.getElementById("review-theater");
   const video = document.getElementById("review-video");
   const title = document.getElementById("review-title");
@@ -13,7 +14,54 @@
   const counts = document.getElementById("review-counts");
   const buttons = [...theater.querySelectorAll("[data-review-decision]")];
   const closeBtn = document.getElementById("review-close");
-  let items = [], index = 0, decisions = load(), lastFocused = null;
+  let items = [], index = 0, decisions = load(), lastFocused = null, syncTimer = null;
+
+  // Server-side persistence: decisions survive the browser and drive the
+  // kept-clips ZIP export. UI verbs (keep/skip) map to server verdicts.
+  function projectId() { return localStorage.getItem("cf-project"); }
+  function toServer(map) {
+    const out = {};
+    for (const [k, v] of Object.entries(map)) {
+      if (v === "keep" || v === "maybe" || v === "skip") {
+        out[k] = { verdict: v === "keep" ? "kept" : v === "skip" ? "skipped" : "maybe", updated_at: new Date().toISOString() };
+      }
+    }
+    return { decisions: out };
+  }
+  function sync() {
+    clearTimeout(syncTimer);
+    syncTimer = setTimeout(() => {
+      const pid = projectId();
+      if (!pid) return;
+      fetch(`/api/projects/${pid}/decisions`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(toServer(decisions)),
+      }).catch(() => {});
+    }, 400);
+  }
+  async function pullServerDecisions() {
+    const pid = projectId();
+    if (!pid) return;
+    try {
+      const res = await fetch(`/api/projects/${pid}/decisions`);
+      if (!res.ok) return;
+      const data = await res.json();
+      let changed = false;
+      for (const [k, entry] of Object.entries(data.decisions || {})) {
+        if (!decisions[k]) {
+          decisions[k] = entry.verdict === "kept" ? "keep" : entry.verdict === "skipped" ? "skip" : "maybe";
+          changed = true;
+        }
+      }
+      if (changed) { save(); paint(); updateCounts(); }
+    } catch (_) {}
+  }
+  function updateExportButton(keptCount) {
+    if (!exportBtn) return;
+    exportBtn.hidden = !items.length || !keptCount || !projectId();
+    if (!exportBtn.hidden) exportBtn.textContent = `Download kept (${keptCount})`;
+  }
 
   function load() {
     try { return JSON.parse(localStorage.getItem(STORE) || "{}") || {}; } catch (_) { return {}; }
@@ -37,6 +85,7 @@
     });
     openBtn.hidden = !items.length;
     paint();
+    updateCounts();
     if (!theater.hidden) {
       if (!items.length) closeReview();
       else { index = Math.min(index, items.length - 1); show(false); }
@@ -63,6 +112,7 @@
     const t = { keep: 0, maybe: 0, skip: 0 };
     for (const [k, v] of Object.entries(decisions)) if (keys.has(k) && v in t) t[v]++;
     counts.textContent = ` · ${t.keep} keep · ${t.maybe} maybe · ${t.skip} skip`;
+    updateExportButton(t.keep);
   }
   function show(autoplay = true) {
     const item = items[index];
@@ -98,6 +148,7 @@
     if (!item) return;
     decisions[item.key] = value;
     save();
+    sync();
     paint();
     if (index < items.length - 1) { index++; show(true); }
     else show(false);
@@ -113,6 +164,11 @@
   openBtn.addEventListener("click", openReview);
   closeBtn.addEventListener("click", closeReview);
   for (const b of buttons) b.addEventListener("click", () => decide(b.dataset.reviewDecision));
+  if (exportBtn) exportBtn.addEventListener("click", () => {
+    const pid = projectId();
+    if (pid) window.location.href = `/api/projects/${pid}/export?verdicts=kept`;
+  });
+  pullServerDecisions();
 
   document.addEventListener("keydown", (event) => {
     if (typing(event.target)) return;


### PR DESCRIPTION
## What changed

Review triage (keep/maybe/skip) lived only in localStorage, keyed by clip path, and every clip download was its own click. This makes triage durable server-side and turns it into the export filter.

- `decisions.json` per project via `Store`: `{ decisions: { [clip_path]: { verdict: kept|maybe|skipped, updated_at } } }`
- `GET /api/projects/{id}/decisions` — load (empty map when none yet)
- `PUT /api/projects/{id}/decisions` — full-map replace; verdict enum enforced by the typed extractor (unknown variants 422 at the boundary), keys must belong to the project (400 otherwise)
- `GET /api/projects/{id}/export?verdicts=kept` — streams a ZIP of ready clips whose decision matches the comma-separated verdict filter (default `kept`); built to a temp file in the project dir via spawn_blocking so large exports never sit in RAM
- Studio: review theater syncs decisions to the server debounced (400 ms), pulls server decisions on load to fill gaps, and the results header gains **Download kept (N)** when any clip is kept

## Proof on the running app

Booted the real server (`CF_DATA_DIR=/tmp/cf-proof-data CF_PORT=4599`), created a project through `POST /api/projects`, dropped a fixture manifest + clip files into the project dir, then:

- `PUT /decisions` → 200, map persisted; `GET /decisions` returns it
- `GET /export` → 200 `application/zip`, `clips-kept.zip`, contains exactly `01-strong-open.mp4`; `unzip -p` byte-matches the kept clip
- `GET /export?verdicts=skipped` → zip with only `02-weak.mp4`; `verdicts=kept,maybe` → 200
- Negatives: `verdicts=bogus` → 400; foreign decision key → 400; invalid verdict in PUT → 422 serde error; unknown project → 404

## Gates

- `cargo test`: 115 passed (4 new: store roundtrip+default, strict verdict parsing, decisions API incl. foreign-key/unknown-project rejection, export ZIP filter incl. empty/bad-filter)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean