### PR TITLE
feat: one-click sample episode on the empty state

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -L -o ~/.clipping-factory/models/ggml-base.en.bin \
 cargo run --release
 ```
 
-The studio opens at [http://localhost:4571](http://localhost:4571). Drop in one MP4 and the pipeline starts.
+The studio opens at [http://localhost:4571](http://localhost:4571). Drop in one MP4 and the pipeline starts. No episode handy? **Run the sample** on the empty state synthesizes a short demo episode in your data directory (macOS speech narration over a generated video pattern, or a sine tone where speech synthesis is unavailable) and runs it through the same pipeline. The sample is procedurally generated at runtime — the repository ships no media, and nothing copyrighted is involved.
 
 ### Linux
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,6 +5,7 @@
 //! POST   /api/settings/ai/test       verify connectivity
 //! GET    /api/setup                  first-run environment checks
 //! POST   /api/projects               multipart MP4 upload → project (auto-starts)
+//! POST   /api/sample                 synthesize + run the demo episode (auto-starts)
 //! GET    /api/projects/{id}          full project view
 //! GET    /api/projects/{id}/events   SSE progress stream
 //! POST   /api/projects/{id}/process  start/resume
@@ -45,6 +46,7 @@ pub fn router(state: AppState) -> Router {
         .route("/api/settings/ai", get(get_settings).post(set_settings))
         .route("/api/settings/ai/test", post(test_settings))
         .route("/api/projects", post(create_project))
+        .route("/api/sample", post(create_sample))
         .route("/api/projects/{id}", get(get_project))
         .route("/api/projects/{id}/events", get(project_events))
         .route("/api/projects/{id}/process", post(process_project))
@@ -431,26 +433,87 @@ async fn create_project(
     project.caption_style = fields.caption_style;
     project.accent_color = fields.accent_color;
     project.framing_mode = fields.framing_mode;
-    if let Err(error) = state.store.save_project(&project).await {
+    match finish_project_creation(&state, &id, project, fields.original_name.clone()).await {
+        Ok(()) => {
+            cleanup.disarm();
+            let view = project_view(&state, &id).await.map_err(ApiError::from)?;
+            Ok(Json(view))
+        }
+        Err(error) => {
+            cleanup_upload(&state, &id).await;
+            cleanup.disarm();
+            Err(error)
+        }
+    }
+}
+
+/// Persist the project record + source sidecar, then auto-start the pipeline
+/// (PRD §7.2). Shared by upload and the sample endpoint so both ride the
+/// exact same creation path.
+async fn finish_project_creation(
+    state: &AppState,
+    id: &str,
+    project: Project,
+    original_name: String,
+) -> Result<(), ApiError> {
+    state
+        .store
+        .save_project(&project)
+        .await
+        .map_err(ApiError::from)?;
+    // The original filename lives in a sidecar file; the inspect stage and
+    // output-folder naming read it from there.
+    tokio::fs::write(
+        state.store.project_dir(id).join("original-name.txt"),
+        original_name,
+    )
+    .await
+    .ok();
+    pipeline::start(state.clone(), id.to_string()).await.ok();
+    Ok(())
+}
+
+async fn create_sample(State(state): State<AppState>) -> Result<Json<serde_json::Value>, ApiError> {
+    let id = crate::util::short_id();
+    let mut cleanup = UploadCleanupGuard::new(state.store.project_dir(&id));
+
+    let source = match crate::sample::ensure_sample(&state.cfg.data_dir, &state.cfg.ffmpeg).await {
+        Ok(path) => path,
+        Err(error) => {
+            cleanup.disarm();
+            return Err(ApiError::from(anyhow::anyhow!(
+                "Could not synthesize the sample episode: {error:#}"
+            )));
+        }
+    };
+
+    if let Err(error) = state.store.create_dirs(&id).await {
         cleanup_upload(&state, &id).await;
         cleanup.disarm();
         return Err(ApiError::from(error));
     }
-    cleanup.disarm();
-    // The original filename lives in a sidecar file; the inspect stage and
-    // output-folder naming read it from there.
-    tokio::fs::write(
-        state.store.project_dir(&id).join("original-name.txt"),
-        &fields.original_name,
-    )
-    .await
-    .ok();
+    let dest = state.store.source_path(&id);
+    if let Err(error) = tokio::fs::copy(&source, &dest).await {
+        cleanup_upload(&state, &id).await;
+        cleanup.disarm();
+        return Err(ApiError::from(anyhow::anyhow!(
+            "Could not copy the sample into the project: {error}"
+        )));
+    }
 
-    // Processing begins automatically (PRD §7.2).
-    pipeline::start(state.clone(), id.clone()).await.ok();
-
-    let view = project_view(&state, &id).await.map_err(ApiError::from)?;
-    Ok(Json(view))
+    let project = Project::new(id.clone(), dest);
+    match finish_project_creation(&state, &id, project, "Sample Episode.mp4".to_string()).await {
+        Ok(()) => {
+            cleanup.disarm();
+            let view = project_view(&state, &id).await.map_err(ApiError::from)?;
+            Ok(Json(view))
+        }
+        Err(error) => {
+            cleanup_upload(&state, &id).await;
+            cleanup.disarm();
+            Err(error)
+        }
+    }
 }
 
 async fn get_project(
@@ -1292,6 +1355,45 @@ mod tests {
             verdict,
             updated_at: chrono::Utc::now(),
         }
+    }
+
+    #[tokio::test]
+    async fn create_sample_rides_the_standard_creation_path() {
+        let tmp = std::env::temp_dir().join(format!("cf-sample-api-{}", crate::util::short_id()));
+        let mut cfg = crate::config::Config::resolve();
+        cfg.data_dir = tmp.join("data");
+        cfg.output_root = tmp.join("output");
+        let state = AppState::new(cfg);
+
+        let response = match create_sample(State(state.clone())).await {
+            Ok(Json(v)) => v,
+            Err(e) => panic!("sample creation should succeed: {:?}", e.0),
+        };
+        let id = response["project"]["id"]
+            .as_str()
+            .expect("project id")
+            .to_string();
+
+        let project = state.store.load_project(&id).await.unwrap();
+        assert_eq!(project.source_path, state.store.source_path(&id));
+        assert!(
+            state.store.source_path(&id).is_file(),
+            "source must be copied into the project"
+        );
+        let sidecar = state.store.project_dir(&id).join("original-name.txt");
+        assert_eq!(
+            tokio::fs::read_to_string(sidecar).await.unwrap(),
+            "Sample Episode.mp4"
+        );
+        assert!(
+            crate::sample::sample_path(&state.cfg.data_dir).is_file(),
+            "sample must be cached in the data dir"
+        );
+
+        tokio::fs::remove_dir_all(tmp).await.ok();
+        tokio::fs::remove_dir_all(state.store.project_dir(&id))
+            .await
+            .ok();
     }
 
     async fn export_fixture_state(tag: &str) -> (AppState, String) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod frame;
 mod media;
 mod pipeline;
 mod render;
+mod sample;
 mod select;
 mod settings;
 mod state;

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -1,0 +1,147 @@
+//! First-run sample episode, synthesized on demand so no media ships in the
+//! repo. Narration uses macOS `say` when available so the transcriber gets
+//! real speech; otherwise a sine tone stands in. The video track is ffmpeg's
+//! generated testsrc2 pattern. Everything is procedurally produced at runtime:
+//! no third-party or copyrighted media is involved.
+
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+use anyhow::{anyhow, Context};
+
+const SCRIPT: &str = "\
+Here is what makes a moment worth clipping. A strong clip opens clean, makes one point, and lands its payoff before your thumb can scroll away.\n\
+Most podcast video fails for a boring reason. The cut starts mid-thought, or it runs long past the punchline, and the viewer is gone.\n\
+Clipping Factory reads the full transcript first. Every sentence gets timed word by word, so nothing is guessed and nothing is invented later.\n\
+The selector looks for tension, surprise, and small complete stories. Conflict outranks a hot take. A confession outranks a joke.\n\
+A deterministic validator has the final word. If a candidate depends on missing context, or overlaps a stronger moment, it gets rejected.\n\
+That gate is why the shortlist stays short. Ten honest candidates beat fifty forgettable ones.\n\
+Framing comes next. When a face is detected, the crop follows it through the frame. When none is found, the clip falls back to a soft blurred pad instead of guessing.\n\
+Captions are burned in word accurately, in the style and accent color you picked, so the clip posts without another editing pass.\n\
+Everything runs on this machine. The video never leaves it, the transcript never leaves it, and no account exists anywhere.\n\
+Review is one keypress per clip. Keep the strong ones, skip the rest, and download everything you kept as a single archive.\n\
+That is the entire workflow. One episode in, a stack of postable clips out. Drop your own podcast whenever you are ready.";
+
+/// Where the synthesized sample lives; cached across runs and projects.
+pub fn sample_path(data_dir: &Path) -> PathBuf {
+    data_dir.join("sample").join("sample-episode.mp4")
+}
+
+/// Return the cached sample, synthesizing it first if absent.
+pub async fn ensure_sample(data_dir: &Path, ffmpeg: &str) -> anyhow::Result<PathBuf> {
+    let dest = sample_path(data_dir);
+    if tokio::fs::metadata(&dest)
+        .await
+        .map(|m| m.len() > 0)
+        .unwrap_or(false)
+    {
+        return Ok(dest);
+    }
+    tokio::fs::create_dir_all(dest.parent().expect("sample path has a parent"))
+        .await
+        .context("creating sample dir")?;
+
+    let work = std::env::temp_dir().join(format!("cf-sample-{}", crate::util::short_id()));
+    tokio::fs::create_dir_all(&work)
+        .await
+        .context("creating sample work dir")?;
+    let result = match narrate(&work).await {
+        Some(aiff) => {
+            render(
+                ffmpeg,
+                &["-i", aiff.to_string_lossy().as_ref()],
+                &dest,
+                true,
+            )
+            .await
+        }
+        None => {
+            tracing::warn!("`say` unavailable; synthesizing sample with a sine tone");
+            render(
+                ffmpeg,
+                &["-f", "lavfi", "-i", "sine=frequency=200:duration=24"],
+                &dest,
+                false,
+            )
+            .await
+        }
+    };
+    tokio::fs::remove_dir_all(&work).await.ok();
+    result?;
+    Ok(dest)
+}
+
+/// Produce narration via macOS speech synthesis; None when unavailable.
+async fn narrate(dir: &Path) -> Option<PathBuf> {
+    let say = PathBuf::from("/usr/bin/say");
+    if !say.exists() {
+        return None;
+    }
+    let script = dir.join("script.txt");
+    tokio::fs::write(&script, SCRIPT).await.ok()?;
+    let aiff = dir.join("narration.aiff");
+    let status = Command::new(&say)
+        .arg("-f")
+        .arg(&script)
+        .arg("-o")
+        .arg(&aiff)
+        .status()
+        .await
+        .ok()?;
+    status.success().then_some(aiff)
+}
+
+async fn render(
+    ffmpeg: &str,
+    audio_args: &[&str],
+    dest: &Path,
+    shortest: bool,
+) -> anyhow::Result<()> {
+    let mut args: Vec<&str> = vec!["-y", "-f", "lavfi", "-i", "testsrc2=size=1280x720:rate=30"];
+    args.extend_from_slice(audio_args);
+    if shortest {
+        args.push("-shortest");
+    }
+    args.extend_from_slice(&[
+        "-c:v", "libx264", "-preset", "veryfast", "-pix_fmt", "yuv420p", "-c:a", "aac",
+    ]);
+    let out = Command::new(ffmpeg)
+        .args(&args)
+        .arg(dest)
+        .output()
+        .await
+        .context("running ffmpeg for sample synthesis")?;
+    if !out.status.success() {
+        return Err(anyhow!(
+            "ffmpeg failed synthesizing the sample: {}",
+            String::from_utf8_lossy(&out.stderr)
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn existing_sample_is_reused_without_synthesis() {
+        let tmp = std::env::temp_dir().join(format!("cf-sample-{}", crate::util::short_id()));
+        let data_dir = tmp.join("data");
+        tokio::fs::create_dir_all(sample_path(&data_dir).parent().unwrap())
+            .await
+            .unwrap();
+        tokio::fs::write(sample_path(&data_dir), b"cached")
+            .await
+            .unwrap();
+
+        let got = ensure_sample(&data_dir, "/nonexistent-ffmpeg")
+            .await
+            .expect("cached sample should short-circuit");
+
+        assert_eq!(got, sample_path(&data_dir));
+        let bytes = tokio::fs::read(&got).await.unwrap();
+        assert_eq!(bytes, b"cached");
+        tokio::fs::remove_dir_all(tmp).await.ok();
+    }
+}

--- a/static/app.js
+++ b/static/app.js
@@ -141,6 +141,7 @@
   function wireUpload() {
     const drop = $("drop");
     $("choose-btn").addEventListener("click", () => $("file-input").click());
+    $("sample-btn").addEventListener("click", runSample);
     $("file-input").addEventListener("change", (e) => {
       if (e.target.files[0]) uploadFile(e.target.files[0]);
     });
@@ -254,6 +255,27 @@
       resetToEmpty({ message: "Upload failed. Check that the local server is still running." });
     };
     xhr.send(form);
+  }
+
+  async function runSample() {
+    if (uploadXhr) return;
+    $("drop").classList.add("hidden");
+    $("upload-progress").classList.remove("hidden");
+    $("cancel-upload-btn").disabled = true;
+    setUploadPhase("Preparing sample episode…", null);
+    try {
+      const res = await fetch("/api/sample", { method: "POST" });
+      const v = await res.json();
+      if (!res.ok) throw new Error(v.error || "The sample could not be created.");
+      projectId = v.project.id;
+      localStorage.setItem("cf-project", projectId);
+      view = v;
+      clearActionMessage();
+      connectSse();
+      render();
+    } catch (err) {
+      resetToEmpty({ message: err.message || "The sample could not be created." });
+    }
   }
 
   function setUploadPhase(label, percent) {

--- a/static/index.html
+++ b/static/index.html
@@ -30,6 +30,7 @@
         <strong>Drop one podcast MP4 here</strong>
         <p class="muted">The original stays on this computer. Clips keep the original conversation intact — one continuous excerpt each, no invented speech.</p>
         <button id="choose-btn" class="primary" type="button">Choose MP4</button>
+        <button id="sample-btn" type="button">Run the sample</button>
         <input id="file-input" type="file" accept="video/mp4,.mp4,.m4v" hidden>
         <fieldset class="framing-choice">
           <legend>Output framing</legend>


### PR DESCRIPTION
## What

Implements codingwithb/clipping-factory#24: a **Run the sample** button on the empty state. One click synthesizes a demo episode and runs it through the standard pipeline, so a fresh visitor sees finished, caption-burned clips without supplying an MP4.

## How

- `POST /api/sample` synthesizes the sample on first use into `<data_dir>/sample/sample-episode.mp4` and caches it. Narration is macOS `say` speech over an ffmpeg `testsrc2` pattern; where `say` is unavailable it falls back to a sine tone. **The repo ships no media** — everything is procedurally generated at runtime, so no copyrighted or third-party material is involved (license note in README, Quickstart section).
- Upload and sample share one creation path: `finish_project_creation` (save project → original-name sidecar → `pipeline::start`). No parallel pipeline; caption-only bypass and all stage behavior are identical to a normal upload.
- Sample length is ~86s deliberately: the local selector only proposes 20–90s windows (`select/heuristic.rs` MIN_MS/MAX_MS), and a first draft at 26s produced zero proposals by design. ~86s also matches the issue's "~90s sample source".
- UI: `sample-btn` in the empty state; `runSample()` reuses the existing progress/SSE/results flow.

## Proof on the real app

Built server, fresh data dir, `POST /api/sample` → HTTP 200, polled to terminal state:

```
inspecting            1280×720 · 01:26 · h264/aac
extracting_audio      16 kHz mono audio ready
transcribing          246 words · avg confidence 96%
selecting_candidates  2 proposal(s) from local ranking
validating_candidates 2 passed · 0 rejected
analyzing_layout      2 layout(s) planned · 2 face-tracked
rendering             2 of 2 clip(s) rendered
```

Final state `complete`, 2 Ready clips on disk with word-timed captions. Served `index.html` contains `sample-btn`.

## Gates

- `cargo test --all-targets`: 117 passed / 0 failed (incl. new `create_sample_rides_the_standard_creation_path` + `existing_sample_is_reused_without_synthesis`)
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo fmt --all --check`: clean

## Notes for review

- Environment had `whisper-cli` + `ggml-base.en`, so the full path fired (not the caption-only bypass). Without a model, the pipeline fails at transcribing with the existing setup banner guidance — same as any upload; the sample itself still synthesizes and caches.
- Testsynth video's shapes register as "faces" to the detector, so layout says face-tracked; harmless for a demo.
- Stacked on #33 (poteto/batch-restyle). Do not merge before the parent PR.