### PR TITLE
fix: clear caption restyle drafts when a project resets

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -302,6 +302,8 @@
     cancellationPending = false;
     retryPending = false;
     uploadCancelRequested = false;
+    applyAllState.draft = null;
+    for (const k of Object.keys(restyleState)) delete restyleState[k];
     localStorage.removeItem("cf-project");
     if (sse) { sse.close(); sse = null; }
     $("drop").classList.remove("hidden");


### PR DESCRIPTION
One-line follow-up to #33 found in verification: the apply-to-all draft and per-clip restyle drafts persisted across project resets, so a style picked in one project leaked into the next project's pickers. resetToEmpty now clears both.

Gates: cargo test 117/0, clippy -D warnings clean, fmt clean. Proven on the running server (served /app.js contains the reset).